### PR TITLE
Dispatch an event when an image is resized

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~1.8",
         "phpunit/phpunit": "~4.5",
-        "satooshi/php-coveralls": "~0.6"
+        "satooshi/php-coveralls": "~0.6",
+        "symfony/event-dispatcher": "~2.8|~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Event/ContaoImageEvents.php
+++ b/src/Event/ContaoImageEvents.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\Image\Event;
+
+/**
+ * Defines constants for the Contao image events.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+final class ContaoImageEvents
+{
+    /**
+     * The contao.image.resize_image event is triggered when an image is resized.
+     *
+     * @var string
+     *
+     * @see Contao\Image\Event\ResizeImageEvent
+     */
+    const RESIZE_IMAGE = 'contao.image.resize_image';
+}

--- a/src/Event/ResizeImageEvent.php
+++ b/src/Event/ResizeImageEvent.php
@@ -119,9 +119,9 @@ class ResizeImageEvent extends Event
     /**
      * Sets the resized image.
      *
-     * @param ImageInterface $image
+     * @param ImageInterface|null $image
      */
-    public function setResizedImage(ImageInterface $image)
+    public function setResizedImage(ImageInterface $image = null)
     {
         $this->resizedImage = $image;
     }

--- a/src/Event/ResizeImageEvent.php
+++ b/src/Event/ResizeImageEvent.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of Contao.
+ *
+ * Copyright (c) 2005-2016 Leo Feyer
+ *
+ * @license LGPL-3.0+
+ */
+
+namespace Contao\Image\Event;
+
+use Contao\Image\ImageInterface;
+use Contao\Image\ResizeCoordinatesInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Allows to set a resized image.
+ *
+ * @author Leo Feyer <https://github.com/leofeyer>
+ */
+class ResizeImageEvent extends Event
+{
+    /**
+     * @var ImageInterface
+     */
+    private $image;
+
+    /**
+     * @var ResizeCoordinatesInterface
+     */
+    private $coordinates;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array
+     */
+    private $imagineOptions;
+
+    /**
+     * @var ImageInterface
+     */
+    private $resizedImage;
+
+    /**
+     * Constructor.
+     *
+     * @param ImageInterface             $image
+     * @param ResizeCoordinatesInterface $coordinates
+     * @param string                     $path
+     * @param array                      $imagineOptions
+     */
+    public function __construct(
+        ImageInterface $image,
+        ResizeCoordinatesInterface $coordinates,
+        $path,
+        array $imagineOptions
+    ) {
+        $this->image = $image;
+        $this->coordinates = $coordinates;
+        $this->path = $path;
+        $this->imagineOptions = $imagineOptions;
+    }
+
+    /**
+     * Returns the image object.
+     *
+     * @return ImageInterface
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * Returns the coordinates object.
+     *
+     * @return ResizeCoordinatesInterface
+     */
+    public function getCoordinates()
+    {
+        return $this->coordinates;
+    }
+
+    /**
+     * Returns the path.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Returns the Imagine options.
+     *
+     * @return array
+     */
+    public function getImagineOptions()
+    {
+        return $this->imagineOptions;
+    }
+
+    /**
+     * Returns the resized image.
+     *
+     * @return ImageInterface
+     */
+    public function getResizedImage()
+    {
+        return $this->resizedImage;
+    }
+
+    /**
+     * Sets the resized image.
+     *
+     * @param ImageInterface $image
+     */
+    public function setResizedImage(ImageInterface $image)
+    {
+        $this->resizedImage = $image;
+    }
+}

--- a/src/Picture.php
+++ b/src/Picture.php
@@ -48,7 +48,7 @@ class Picture implements PictureInterface
      */
     public function getImg($rootDir = null)
     {
-        if ($rootDir === null) {
+        if (null === $rootDir) {
             return $this->img;
         }
 
@@ -60,7 +60,7 @@ class Picture implements PictureInterface
      */
     public function getSources($rootDir = null)
     {
-        if ($rootDir === null) {
+        if (null === $rootDir) {
             return $this->sources;
         }
 

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -75,7 +75,7 @@ class Resizer implements ResizerInterface
      *
      * @return ImageInterface
      */
-    protected function processResize(
+    private function processResize(
         ImageInterface $image,
         ResizeConfigurationInterface $config,
         ResizeOptionsInterface $options
@@ -109,7 +109,7 @@ class Resizer implements ResizerInterface
      *
      * @return ImageInterface
      */
-    protected function executeResize(
+    private function executeResize(
         ImageInterface $image,
         ResizeCoordinatesInterface $coordinates,
         $path,
@@ -138,7 +138,7 @@ class Resizer implements ResizerInterface
      *
      * @return ImageInterface
      */
-    protected function createImage(ImageInterface $image, $path)
+    private function createImage(ImageInterface $image, $path)
     {
         return new Image($image->getImagine(), $this->filesystem, $path);
     }
@@ -151,7 +151,7 @@ class Resizer implements ResizerInterface
      *
      * @return string The realtive target path
      */
-    protected function createCachePath($path, ResizeCoordinatesInterface $coordinates)
+    private function createCachePath($path, ResizeCoordinatesInterface $coordinates)
     {
         $pathinfo = pathinfo($path);
         $hash = substr(md5(implode('|', [$path, filemtime($path), $coordinates->getHash()])), 0, 9);

--- a/src/ResizerInterface.php
+++ b/src/ResizerInterface.php
@@ -10,7 +10,7 @@
 
 namespace Contao\Image;
 
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -23,16 +23,16 @@ interface ResizerInterface
     /**
      * Constructor.
      *
-     * @param ResizeCalculatorInterface $calculator
-     * @param Filesystem                $filesystem
-     * @param string                    $path
-     * @param EventDispatcher           $eventDispatcher
+     * @param ResizeCalculatorInterface     $calculator
+     * @param Filesystem                    $filesystem
+     * @param string                        $path
+     * @param EventDispatcherInterface|null $eventDispatcher
      */
     public function __construct(
         ResizeCalculatorInterface $calculator,
         Filesystem $filesystem,
         $path,
-        EventDispatcher $eventDispatcher
+        EventDispatcherInterface $eventDispatcher = null
     );
 
     /**

--- a/src/ResizerInterface.php
+++ b/src/ResizerInterface.php
@@ -10,6 +10,7 @@
 
 namespace Contao\Image;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -25,8 +26,14 @@ interface ResizerInterface
      * @param ResizeCalculatorInterface $calculator
      * @param Filesystem                $filesystem
      * @param string                    $path
+     * @param EventDispatcher           $eventDispatcher
      */
-    public function __construct(ResizeCalculatorInterface $calculator, Filesystem $filesystem, $path);
+    public function __construct(
+        ResizeCalculatorInterface $calculator,
+        Filesystem $filesystem,
+        $path,
+        EventDispatcher $eventDispatcher
+    );
 
     /**
      * Resizes an Image object.

--- a/tests/ResizerTest.php
+++ b/tests/ResizerTest.php
@@ -562,7 +562,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
         $configuration = $this->getMock('Contao\Image\ResizeConfigurationInterface');
         $resizedImage = $resizer->resize($image, $configuration, new ResizeOptions());
 
-        $this->assertEquals($resizedImage, $customImage);
+        $this->assertSame($resizedImage, $customImage);
     }
 
     /**


### PR DESCRIPTION
This PR adds the `contao.image.resize_image` event, which is dispatched when an image is resized (`Resizer::executeResize`).

I have chosen `resize_image` instead of just `resize` so the class is called `ResizeImageEvent` instead of `ResizeEvent` and the constant is called `ContaoImageEvents::RESIZE_IMAGE` instead of `ContaoImageEvents::RESIZE`. I can change this though if you want.