### PR TITLE
Better performance for reading dimensions of SVG images

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Contao image library
 [![](https://img.shields.io/travis/contao/image/master.svg?style=flat-square)](https://travis-ci.org/contao/image/)
 [![](https://img.shields.io/scrutinizer/g/contao/image/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/contao/image/)
 [![](https://img.shields.io/coveralls/contao/image/master.svg?style=flat-square)](https://coveralls.io/github/contao/image)
+[![](https://img.shields.io/packagist/v/contao/image.svg?style=flat-square)](https://packagist.org/packages/contao/image)
+[![](https://img.shields.io/packagist/dt/contao/image.svg?style=flat-square)](https://packagist.org/packages/contao/image)
 
 This library provides methods to resize images based on resize configurations
 and generates responsive images to be used with `<picture>` and `srcset`. It is

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,14 @@ platform: x86
 clone_folder: c:\projects\contao-image
 
 init:
+  - SET PATH=c:\php;%PATH%
   - SET SYMFONY_DEPRECATIONS_HELPER=weak
 
 install:
-  - cinst -y OpenSSL.Light
-  - SET PATH=C:\Program Files\OpenSSL;%PATH%
-  - cinst -y php
-  - cd c:\tools\php
+  - mkdir c:\php && cd c:\php
+  - appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.6.25-Win32-VC11-x86.zip
+  - 7z x php-5.6.25-Win32-VC11-x86.zip -y >nul
+  - del *.zip
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
   - echo extension_dir=ext >> php.ini
@@ -28,7 +29,6 @@ install:
   - echo extension=php_sockets.dll >> php.ini
   - echo extension=php_xmlrpc.dll >> php.ini
   - echo extension=php_xsl.dll >> php.ini
-  - SET PATH=c:\tools\php;%PATH%
   - cd c:\projects\contao-image
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar update --no-progress --no-interaction --ansi

--- a/src/Image.php
+++ b/src/Image.php
@@ -176,15 +176,27 @@ class Image implements ImageInterface
      */
     private function getSvgSize()
     {
+        static $zlibSupport;
+
+        if (null === $zlibSupport) {
+            $zlibSupport = in_array('compress.zlib', stream_get_wrappers());
+        }
+
         $size = null;
         $reader = new XMLReader();
+
+        $path = $this->path;
+
+        if ($zlibSupport) {
+            $path = 'compress.zlib://'.$path;
+        }
 
         // Enable the entity loader at first to make XMLReader::open() work
         // see https://bugs.php.net/bug.php?id=73328
         $disableEntities = libxml_disable_entity_loader(false);
         $internalErrors = libxml_use_internal_errors(true);
 
-        if ($reader->open('compress.zlib://'.$this->path, LIBXML_NONET)) {
+        if ($reader->open($path, LIBXML_NONET)) {
 
             // After opening the file disable the entity loader for security reasons
             libxml_disable_entity_loader(true);

--- a/src/Image.php
+++ b/src/Image.php
@@ -10,11 +10,17 @@
 
 namespace Contao\Image;
 
+use Contao\ImagineSvg\Image as SvgImage;
+use Contao\ImagineSvg\Imagine as SvgImagine;
+use DOMDocument;
 use Imagine\Image\Box;
+use Imagine\Image\BoxInterface;
 use Imagine\Image\ImagineInterface;
+use Imagine\Image\Metadata\MetadataBag;
 use Imagine\Image\Point;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
+use XMLReader;
 
 /**
  * Image class.
@@ -112,13 +118,27 @@ class Image implements ImageInterface
     public function getDimensions()
     {
         if (null === $this->dimensions) {
-            $size = @getimagesize($this->getPath()); // try native getimagesize() for better performance
 
-            if (!empty($size[0]) && !empty($size[1])) {
-                $this->dimensions = new ImageDimensions(new Box($size[0], $size[1]));
+            // Try getSvgSize() or native getimagesize() for better performance
+            if ($this->imagine instanceof SvgImagine) {
+                $size = $this->getSvgSize();
+
+                if (null !== $size) {
+                    $this->dimensions = new ImageDimensions($size);
+                }
             } else {
-                $this->dimensions = new ImageDimensions($this->imagine->open($this->getPath())->getSize());
+                $size = @getimagesize($this->path);
+
+                if (!empty($size[0]) && !empty($size[1])) {
+                    $this->dimensions = new ImageDimensions(new Box($size[0], $size[1]));
+                }
             }
+
+            // Fall back to Imagine
+            if (null === $this->dimensions) {
+                $this->dimensions = new ImageDimensions($this->imagine->open($this->path)->getSize());
+            }
+
         }
 
         return $this->dimensions;
@@ -144,5 +164,72 @@ class Image implements ImageInterface
         $this->importantPart = $importantPart;
 
         return $this;
+    }
+
+    /**
+     * Reads the SVG image file partially and returns the size of it.
+     *
+     * This is faster than reading and parsing the whole SVG file just to get
+     * the size of it, especially for large files.
+     *
+     * @return BoxInterface|null
+     */
+    private function getSvgSize()
+    {
+        $size = null;
+        $reader = new XMLReader();
+
+        // Enable the entity loader at first to make XMLReader::open() work
+        // see https://bugs.php.net/bug.php?id=73328
+        $disableEntities = libxml_disable_entity_loader(false);
+        $internalErrors = libxml_use_internal_errors(true);
+
+        if ($reader->open('compress.zlib://'.$this->path, LIBXML_NONET)) {
+
+            // After opening the file disable the entity loader for security reasons
+            libxml_disable_entity_loader(true);
+
+            $size = $this->getSvgSizeFromReader($reader);
+
+            $reader->close();
+
+        }
+
+        libxml_use_internal_errors($internalErrors);
+        libxml_disable_entity_loader($disableEntities);
+        libxml_clear_errors();
+
+        return $size;
+    }
+
+    /**
+     * Extracts the SVG image size from the given XMLReader object
+     *
+     * @param XMLReader $reader
+     *
+     * @return BoxInterface|null
+     */
+    private function getSvgSizeFromReader(XMLReader $reader)
+    {
+        // Move the pointer to the first element in the document
+        while ($reader->read() && $reader->nodeType !== XMLReader::ELEMENT);
+
+        if ($reader->nodeType !== XMLReader::ELEMENT || $reader->name !== 'svg') {
+            return null;
+        }
+
+        $document = new DOMDocument();
+        $svg = $document->createElement('svg');
+        $document->appendChild($svg);
+
+        foreach (['width', 'height', 'viewBox'] as $key) {
+            if ($value = $reader->getAttribute($key)) {
+                $svg->setAttribute($key, $value);
+            }
+        }
+
+        $image = new SvgImage($document, new MetadataBag());
+
+        return $image->getSize();
     }
 }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -13,6 +13,7 @@ namespace Contao\Image\Test;
 use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImportantPart;
+use Exception;
 use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImagineInterface;
@@ -248,6 +249,31 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $image = $this->createImage($this->rootDir.'/dummy.svg', $imagine);
 
         $this->assertEquals(new ImageDimensions(new Box(1000, 1000)), $image->getDimensions());
+    }
+
+    /**
+     * Tests the getDimensions() method handles invalid SVG images.
+     */
+    public function testGetDimensionsInvalidSvg()
+    {
+        if (!is_dir($this->rootDir)) {
+            mkdir($this->rootDir, 0777, true);
+        }
+
+        file_put_contents($this->rootDir.'/dummy.svg', '<nosvg width="1000" height="1000"></nosvg>');
+
+        $imagine = $this->getMock('Contao\ImagineSvg\Imagine');
+
+        $imagine
+            ->method('open')
+            ->willThrowException(new Exception)
+        ;
+
+        $image = $this->createImage($this->rootDir.'/dummy.svg', $imagine);
+
+        $this->setExpectedException('Exception');
+
+        $image->getDimensions();
     }
 
     /**

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -13,6 +13,7 @@ namespace Contao\Image\Test;
 use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImportantPart;
+use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Point;
@@ -25,6 +26,29 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 class ImageTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var string
+     */
+    private $rootDir;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->rootDir = __DIR__.'/tmp';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tearDown()
+    {
+        if (file_exists($this->rootDir)) {
+            (new Filesystem())->remove($this->rootDir);
+        }
+    }
+
     /**
      * Tests the object instantiation.
      */
@@ -181,6 +205,49 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $image = $this->createImage(null, $imagine);
 
         $this->assertEquals(new ImageDimensions(new Box(100, 100)), $image->getDimensions());
+    }
+
+    /**
+     * Tests the getDimensions() method determines the dimensions without
+     * Imagine and by only reading the file partially.
+     */
+    public function testGetDimensionsPartialFile()
+    {
+        if (!is_dir($this->rootDir)) {
+            mkdir($this->rootDir, 0777, true);
+        }
+
+        $image = (new GdImagine())
+            ->create(new Box(1000, 1000))
+            ->get('jpg')
+        ;
+
+        // Only store the first 500 bytes of the image
+        file_put_contents($this->rootDir.'/dummy.jpg', substr($image, 0, 500));
+
+        $image = $this->createImage($this->rootDir.'/dummy.jpg');
+
+        $this->assertEquals(new ImageDimensions(new Box(1000, 1000)), $image->getDimensions());
+    }
+
+    /**
+     * Tests the getDimensions() method determines the SVG dimensions without
+     * Imagine and by only reading the file partially.
+     */
+    public function testGetDimensionsPartialFileSvg()
+    {
+        $imagine = $this->getMock('Contao\ImagineSvg\Imagine');
+
+        if (!is_dir($this->rootDir)) {
+            mkdir($this->rootDir, 0777, true);
+        }
+
+        // Only store a partial SVG file without an end tag
+        file_put_contents($this->rootDir.'/dummy.svg', '<svg width="1000" height="1000">');
+
+        $image = $this->createImage($this->rootDir.'/dummy.svg', $imagine);
+
+        $this->assertEquals(new ImageDimensions(new Box(1000, 1000)), $image->getDimensions());
     }
 
     /**


### PR DESCRIPTION
With this PR `Image::getDimensions()` reads SVG files only partially to save IO, parsing time and memory. And it doesn’t call `getimagesize()` on SVG images anymore.

### Todo:

* [x] Check if the wrapper [`compress.zlib://`](http://php.net/manual/en/wrappers.compression.php) is supported on all platforms
* [x] Write tests