### PR TITLE
Use an optional image dimensions cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $picture->getSources('/path/to', 'https://example.com/');
 
 ### Image dimensions cache
 
-If `ImageInterface::getDimensions()` gets called often in a project it could
+If `ImageInterface::getDimensions()` gets called often in a project, it could
 make sense to use a cache for the dimensions. Any cache that implements
 [PSR-6][2] can be used, for example the Symfony cache component:
 

--- a/README.md
+++ b/README.md
@@ -107,4 +107,22 @@ $picture->getSources('/path/to', 'https://example.com/');
 ] */
 ```
 
+### Image dimensions cache
+
+If `ImageInterface::getDimensions()` gets called often in a project it could
+make sense to use a cache for the dimensions. Any cache that implements
+[PSR-6][2] can be used, for example the Symfony cache component:
+
+```php
+$imagine = new \Imagine\Gd\Imagine();
+$image = new Image('/path/to/image.jpg', $imagine);
+
+$cache = new \Symfony\Component\Cache\Adapter\FilesystemAdapter();
+$image->setDimensionsCache($cache);
+
+// Uses the $cache object to get the dimensions
+$image->getDimensions();
+```
+
 [1]: https://contao.org
+[2]: http://www.php-fig.org/psr/psr-6/

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">=5.5.0",
         "contao/imagine-svg": "^0.1",
         "imagine/imagine": "^0.6",
+        "psr/cache": "^1.0",
         "symfony/filesystem": "~2.8|~3.0",
         "webmozart/path-util": "^2.0"
     },
@@ -20,6 +21,9 @@
         "friendsofphp/php-cs-fixer": "~1.8",
         "phpunit/phpunit": "~4.5",
         "satooshi/php-coveralls": "~0.6"
+    },
+    "suggest": {
+        "psr/cache-implementation": "For using an image dimensions cache"
     },
     "autoload": {
         "psr-4": {

--- a/src/ImageInterface.php
+++ b/src/ImageInterface.php
@@ -11,6 +11,7 @@
 namespace Contao\Image;
 
 use Imagine\Image\ImagineInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Image interface.
@@ -25,6 +26,22 @@ interface ImageInterface
      * @return ImagineInterface
      */
     public function getImagine();
+
+    /**
+     * Sets the dimensions cache used to cache the image dimensions objects.
+     *
+     * @param CacheItemPoolInterface|null $dimensionsCache
+     *
+     * @return self
+     */
+    public function setDimensionsCache(CacheItemPoolInterface $dimensionsCache = null);
+
+    /**
+     * Returns the dimensions cache instance.
+     *
+     * @return CacheItemPoolInterface|null
+     */
+    public function getDimensionsCache();
 
     /**
      * Returns the path.

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -144,7 +144,8 @@ class Resizer implements ResizerInterface
     protected function createImage(ImageInterface $image, $path)
     {
         return (new Image($path, $image->getImagine(), $this->filesystem))
-            ->setDimensionsCache($image->getDimensionsCache());
+            ->setDimensionsCache($image->getDimensionsCache())
+        ;
     }
 
     /**

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -143,7 +143,8 @@ class Resizer implements ResizerInterface
      */
     protected function createImage(ImageInterface $image, $path)
     {
-        return new Image($path, $image->getImagine(), $this->filesystem);
+        return (new Image($path, $image->getImagine(), $this->filesystem))
+            ->setDimensionsCache($image->getDimensionsCache());
     }
 
     /**

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -277,6 +277,114 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests the getDimensions() method uses the dimenions cache.
+     */
+    public function testGetDimensionsFromCacheHit()
+    {
+        if (!is_dir($this->rootDir)) {
+            mkdir($this->rootDir, 0777, true);
+        }
+
+        file_put_contents($this->rootDir.'/dummy.jpg', '');
+
+        $cache = $this->getMock('Psr\Cache\CacheItemPoolInterface');
+        $cacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+        $dimensions = $this
+            ->getMockBuilder('Contao\Image\ImageDimensionsInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $cache
+            ->method('getItem')
+            ->with($this->matchesRegularExpression('/^[a-z0-9_.]{1,64}$/i'))
+            ->willReturn($cacheItem)
+        ;
+
+        $cacheItem
+            ->method('get')
+            ->willReturn($dimensions)
+        ;
+
+        $cacheItem
+            ->expects($this->never())
+            ->method('set')
+            ->willReturn($dimensions)
+        ;
+
+        $cacheItem
+            ->method('isHit')
+            ->willReturn(true)
+        ;
+
+        $image = $this->createImage($this->rootDir.'/dummy.jpg', null, null, $cache);
+
+        $this->assertSame($dimensions, $image->getDimensions());
+    }
+
+    /**
+     * Tests the getDimensions() method uses the dimenions cache.
+     */
+    public function testGetDimensionsFromCacheMiss()
+    {
+        if (!is_dir($this->rootDir)) {
+            mkdir($this->rootDir, 0777, true);
+        }
+
+        file_put_contents($this->rootDir.'/dummy.jpg', '');
+
+        $imagine = $this->getMock('Imagine\Image\ImagineInterface');
+        $imagineImage = $this->getMock('Imagine\Image\ImageInterface');
+        $cache = $this->getMock('Psr\Cache\CacheItemPoolInterface');
+        $cacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+
+        $imagine
+            ->method('open')
+            ->willReturn($imagineImage)
+        ;
+
+        $imagineImage
+            ->method('getSize')
+            ->willReturn(new Box(100, 100))
+        ;
+
+        $cache
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->matchesRegularExpression('/^[a-z0-9_.]{1,64}$/i'))
+            ->willReturn($cacheItem)
+        ;
+
+        $cache
+            ->expects($this->once())
+            ->method('saveDeferred')
+            ->with($cacheItem)
+            ->willReturn(true)
+        ;
+
+        $cacheItem
+            ->method('get')
+            ->willReturn(null)
+        ;
+
+        $cacheItem
+            ->method('isHit')
+            ->willReturn(false)
+        ;
+
+        $cacheItem
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->equalTo(new ImageDimensions(new Box(100, 100))))
+            ->willReturn($cacheItem)
+        ;
+
+        $image = $this->createImage($this->rootDir.'/dummy.jpg', $imagine, null, $cache);
+
+        $this->assertEquals(new ImageDimensions(new Box(100, 100)), $image->getDimensions());
+    }
+
+    /**
      * Tests the getImportantPart() method.
      */
     public function testGetImportantPart()
@@ -312,7 +420,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
      *
      * @return Image
      */
-    private function createImage($path = null, $imagine = null, $filesystem = null)
+    private function createImage($path = null, $imagine = null, $filesystem = null, $dimensionsCache = null)
     {
         if (null === $path) {
             $path = 'dummy.jpg';
@@ -331,6 +439,12 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             ;
         }
 
-        return new Image($path, $imagine, $filesystem);
+        $image = new Image($path, $imagine, $filesystem);
+
+        if (null !== $dimensionsCache) {
+            $image->setDimensionsCache($dimensionsCache);
+        }
+
+        return $image;
     }
 }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -277,7 +277,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests the getDimensions() method uses the dimenions cache.
+     * Tests the getDimensions() method uses the dimensions cache.
      */
     public function testGetDimensionsFromCacheHit()
     {

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -289,6 +289,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
         $cache = $this->getMock('Psr\Cache\CacheItemPoolInterface');
         $cacheItem = $this->getMock('Psr\Cache\CacheItemInterface');
+
         $dimensions = $this
             ->getMockBuilder('Contao\Image\ImageDimensionsInterface')
             ->disableOriginalConstructor()
@@ -414,9 +415,10 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     /**
      * Creates an image instance helper.
      *
-     * @param string           $path
-     * @param ImagineInterface $imagine
-     * @param Filesystem       $filesystem
+     * @param string|null                 $path
+     * @param ImagineInterface|null       $imagine
+     * @param Filesystem|null             $filesystem
+     * @param CacheItemPoolInterface|null $dimensionsCache
      *
      * @return Image
      */

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -323,7 +323,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests the getDimensions() method uses the dimenions cache.
+     * Tests the getDimensions() method uses the dimensions cache.
      */
     public function testGetDimensionsFromCacheMiss()
     {

--- a/tests/ResizerTest.php
+++ b/tests/ResizerTest.php
@@ -339,6 +339,8 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
 
         file_put_contents($imagePath, '');
 
+        $cache = $this->getMock('Psr\Cache\CacheItemPoolInterface');
+
         /** @var Image|\PHPUnit_Framework_MockObject_MockObject $image */
         $image = $this
             ->getMockBuilder('Contao\Image\Image')
@@ -349,6 +351,11 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
         $image
             ->method('getDimensions')
             ->willReturn(new ImageDimensions(new Box(100, 100)))
+        ;
+
+        $image
+            ->method('getDimensionsCache')
+            ->willReturn($cache)
         ;
 
         $image
@@ -371,6 +378,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
         $resizedImage = $resizer->resize($image, $configuration, new ResizeOptions());
 
         $this->assertEquals($image->getPath(), $resizedImage->getPath());
+        $this->assertSame($cache, $resizedImage->getDimensionsCache());
         $this->assertNotSame($image, $resizedImage);
     }
 


### PR DESCRIPTION
A single request in Contao causes many (hundreds) calls to `Image::getDimensions()`, e.g. for every icon shown on a backend page. A cache for the dimensions off all images would be a big performance boost.

@contao/developers does this implementation make sense that way?
If yes, I can make a pull request to the core-bundle to use the cache there.