### PR TITLE
Make Symfony 3.2 the minimum requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         "php": ">=5.5.0",
         "contao/imagine-svg": "^0.1",
         "imagine/imagine": "^0.6",
-        "symfony/filesystem": "~2.8|~3.0",
+        "symfony/filesystem": "^3.2",
         "webmozart/path-util": "^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~1.8",
-        "phpunit/phpunit": "~4.5",
-        "satooshi/php-coveralls": "~0.6"
+        "friendsofphp/php-cs-fixer": "^1.8",
+        "phpunit/phpunit": "^4.5",
+        "satooshi/php-coveralls": "^0.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As discussed in contao/core-bundle#630, we want to make Symfony 3.2 the minimum version in Contao 4.4. Just in case you need to adjust the `composer.json`, here is a PR for you.