### PR TITLE
[RFC] Allow to set a base dir for Resizer to remove from hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 # Vendor
 /vendor/
-/composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Vendor
 /vendor/
+/composer.lock

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -36,13 +36,19 @@ class Resizer implements ResizerInterface
     private $cacheDir;
 
     /**
+     * @var string
+     */
+    private $baseDir;
+
+    /**
      * Constructor.
      *
      * @param string                         $cacheDir
+     * @param string                         $baseDir
      * @param ResizeCalculatorInterface|null $calculator
      * @param Filesystem|null                $filesystem
      */
-    public function __construct($cacheDir, ResizeCalculatorInterface $calculator = null, Filesystem $filesystem = null)
+    public function __construct($cacheDir, $baseDir = null, ResizeCalculatorInterface $calculator = null, Filesystem $filesystem = null)
     {
         if (null === $calculator) {
             $calculator = new ResizeCalculator();
@@ -53,6 +59,7 @@ class Resizer implements ResizerInterface
         }
 
         $this->cacheDir = (string) $cacheDir;
+        $this->baseDir = $baseDir;
         $this->calculator = $calculator;
         $this->filesystem = $filesystem;
     }
@@ -165,7 +172,7 @@ class Resizer implements ResizerInterface
      * @param ResizeCoordinatesInterface $coordinates
      * @param ResizeOptionsInterface     $options
      *
-     * @return string The realtive target path
+     * @return string The relative target path
      */
     private function createCachePath($path, ResizeCoordinatesInterface $coordinates, ResizeOptionsInterface $options)
     {
@@ -173,8 +180,13 @@ class Resizer implements ResizerInterface
         $imagineOptions = $options->getImagineOptions();
         ksort($imagineOptions);
 
+        $hashPath = $path;
+        if (null !== $this->baseDir) {
+            $hashPath = $this->filesystem->makePathRelative($path, $this->baseDir);
+        }
+
         $hash = substr(md5(implode('|', array_merge(
-            [$path, filemtime($path), $coordinates->getHash()],
+            [$hashPath, filemtime($path), $coordinates->getHash()],
             array_keys($imagineOptions),
             array_values($imagineOptions)
         ))), 0, 9);

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -178,7 +178,7 @@ class Resizer implements ResizerInterface
             [
                 Path::makeRelative($path, $this->cacheDir),
                 filemtime($path),
-                $coordinates->getHash()
+                $coordinates->getHash(),
             ],
             array_keys($imagineOptions),
             array_values($imagineOptions)

--- a/tests/ResizerTest.php
+++ b/tests/ResizerTest.php
@@ -77,7 +77,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, $calculator);
+        $resizer = $this->createResizer(null, null, $calculator);
 
         if (!is_dir($this->rootDir)) {
             mkdir($this->rootDir, 0777, true);
@@ -172,7 +172,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, $calculator);
+        $resizer = $this->createResizer(null, null, $calculator);
 
         $image = $this
             ->getMockBuilder('Contao\Image\Image')
@@ -235,7 +235,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, $calculator);
+        $resizer = $this->createResizer(null, null, $calculator);
 
         if (!is_dir($this->rootDir)) {
             mkdir($this->rootDir, 0777, true);
@@ -411,7 +411,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, $calculator);
+        $resizer = $this->createResizer(null, null, $calculator);
 
         if (!is_dir($this->rootDir)) {
             mkdir($this->rootDir, 0777, true);
@@ -480,7 +480,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, $calculator);
+        $resizer = $this->createResizer(null, null, $calculator);
 
         $image = $this
             ->getMockBuilder('Contao\Image\Image')
@@ -518,17 +518,18 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
      * Creates a resizer instance helper.
      *
      * @param string                    $cacheDir
+     * @param string                    $baseDir
      * @param ResizeCalculatorInterface $calculator
      * @param Filesystem                $filesystem
      *
      * @return Resizer
      */
-    private function createResizer($cacheDir = null, $calculator = null, $filesystem = null)
+    private function createResizer($cacheDir = null, $baseDir = null, $calculator = null, $filesystem = null)
     {
         if (null === $cacheDir) {
             $cacheDir = $this->rootDir;
         }
 
-        return new Resizer($cacheDir, $calculator, $filesystem);
+        return new Resizer($cacheDir, $baseDir, $calculator, $filesystem);
     }
 }

--- a/tests/ResizerTest.php
+++ b/tests/ResizerTest.php
@@ -77,7 +77,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, null, $calculator);
+        $resizer = $this->createResizer(null, $calculator);
 
         if (!is_dir($this->rootDir)) {
             mkdir($this->rootDir, 0777, true);
@@ -172,7 +172,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, null, $calculator);
+        $resizer = $this->createResizer(null, $calculator);
 
         $image = $this
             ->getMockBuilder('Contao\Image\Image')
@@ -235,7 +235,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, null, $calculator);
+        $resizer = $this->createResizer(null, $calculator);
 
         if (!is_dir($this->rootDir)) {
             mkdir($this->rootDir, 0777, true);
@@ -411,7 +411,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, null, $calculator);
+        $resizer = $this->createResizer(null, $calculator);
 
         if (!is_dir($this->rootDir)) {
             mkdir($this->rootDir, 0777, true);
@@ -480,7 +480,7 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
             ->willReturn(new ResizeCoordinates(new Box(100, 100), new Point(0, 0), new Box(100, 100)))
         ;
 
-        $resizer = $this->createResizer(null, null, $calculator);
+        $resizer = $this->createResizer(null, $calculator);
 
         $image = $this
             ->getMockBuilder('Contao\Image\Image')
@@ -518,18 +518,17 @@ class ResizerTest extends \PHPUnit_Framework_TestCase
      * Creates a resizer instance helper.
      *
      * @param string                    $cacheDir
-     * @param string                    $baseDir
      * @param ResizeCalculatorInterface $calculator
      * @param Filesystem                $filesystem
      *
      * @return Resizer
      */
-    private function createResizer($cacheDir = null, $baseDir = null, $calculator = null, $filesystem = null)
+    private function createResizer($cacheDir = null, $calculator = null, $filesystem = null)
     {
         if (null === $cacheDir) {
             $cacheDir = $this->rootDir;
         }
 
-        return new Resizer($cacheDir, $baseDir, $calculator, $filesystem);
+        return new Resizer($cacheDir, $calculator, $filesystem);
     }
 }


### PR DESCRIPTION
The resizer service can then be configured with `%kernel.root_dir%/..` or with `%contao.root_dir%` in Contao 4.4.

**ATTENTION: this is an API change and should result in v0.4**

**TODO:**
 - [ ] do we need `realpath()` to convert `%kernel.root_dir%/..`?
 - [x] Add unit tests