### PR TITLE
Convert images to RGB and strip metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "contao/imagine-svg": "^0.1",
+        "contao/imagine-svg": "dev-fix/missing-methods as 0.1.4",
         "imagine/imagine": "^0.6|^0.7",
         "symfony/filesystem": "^2.8|^3.0",
         "webmozart/path-util": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "contao/imagine-svg": "dev-fix/missing-methods as 0.1.4",
+        "contao/imagine-svg": "^0.1.4",
         "imagine/imagine": "^0.6|^0.7",
         "symfony/filesystem": "^2.8|^3.0",
         "webmozart/path-util": "^2.0"

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -11,6 +11,7 @@
 namespace Contao\Image;
 
 use Imagine\Exception\RuntimeException as ImagineRuntimeException;
+use Imagine\Image\Palette\RGB;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
@@ -129,6 +130,8 @@ class Resizer implements ResizerInterface
             ->open($image->getPath())
             ->resize($coordinates->getSize())
             ->crop($coordinates->getCropStart(), $coordinates->getCropSize())
+            ->usePalette(new RGB())
+            ->strip()
         ;
 
         if (isset($imagineOptions['interlace'])) {


### PR DESCRIPTION
Fixes #34

Blocked on contao/imagine-svg#7 and avalanche123/Imagine#564.