### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "contao/imagine-svg": "^0.1.4",
-        "imagine/imagine": "^0.6|^0.7",
-        "symfony/filesystem": "^2.8|^3.0|^4.0",
+        "imagine/imagine": "^0.6 || ^0.7",
+        "symfony/filesystem": "^2.8 || ^3.0 || ^4.0",
         "webmozart/path-util": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).