### PR TITLE
Preserve the file extension in the temporary file

### DIFF
--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -111,7 +111,7 @@ class Resizer implements ResizerInterface
         }
 
         // Atomic write operation
-        $tmpPath = $this->filesystem->tempnam($dir, 'img');
+        $tmpPath = sys_get_temp_dir().'/'.basename($path);
         $imagineImage->save($tmpPath, $imagineOptions);
         $this->filesystem->rename($tmpPath, $path, true);
 


### PR DESCRIPTION
This will prevent the following error:

```
Imagine\Exception\InvalidArgumentException: Saving image in "tmp" format is not supported, please use one of the following extensions: "gif", "jpeg", "png", "wbmp", "xbm"
```

See https://ci.appveyor.com/project/leofeyer/image/build/1.0.128