### PR TITLE
Autorotate images based on EXIF metadata

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ environment:
   PHPCI_COMPOSER: C:\tools\phpci\composer
 
 cache:
-  - '%PHPCI_CACHE%'
+  - '%PHPCI_CACHE% -> appveyor.yml'
 
 init:
   - SET PATH=%PHPCI_PHP%;%PHPCI_COMPOSER%;%PATH%
@@ -33,6 +33,7 @@ install:
   - IF %PHP%==0 echo extension=php_gd2.dll >> php.ini
   - IF %PHP%==0 echo extension=php_intl.dll >> php.ini
   - IF %PHP%==0 echo extension=php_mbstring.dll >> php.ini
+  - IF %PHP%==0 echo extension=php_exif.dll >> php.ini
   - IF %PHP%==0 echo extension=php_openssl.dll >> php.ini
   - IF %PHP%==0 (composer --version) ELSE (composer self-update)
   - cd %APPVEYOR_BUILD_FOLDER%

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "phpstan/phpstan-phpunit": "^0.10",
         "phpunit/phpunit": "^7.5 || ^8.0"
     },
+    "suggest": {
+        "ext-exif": "To support EXIF auto-rotation"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"

--- a/src/Image.php
+++ b/src/Image.php
@@ -168,8 +168,8 @@ class Image implements ImageInterface
             \in_array(
                 $orientation,
                 [
-                    ImageDimensionsInterface::ORIENTATION_NORMAL_90,
-                    ImageDimensionsInterface::ORIENTATION_NORMAL_270,
+                    ImageDimensionsInterface::ORIENTATION_90,
+                    ImageDimensionsInterface::ORIENTATION_270,
                     ImageDimensionsInterface::ORIENTATION_MIRROR_90,
                     ImageDimensionsInterface::ORIENTATION_MIRROR_270,
                 ],

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -24,6 +24,11 @@ class ImageDimensions implements ImageDimensionsInterface
     private $size;
 
     /**
+     * @var int
+     */
+    private $orientation;
+
+    /**
      * @var bool
      */
     private $relative;
@@ -33,8 +38,12 @@ class ImageDimensions implements ImageDimensionsInterface
      */
     private $undefined;
 
-    public function __construct(BoxInterface $size, bool $relative = null, bool $undefined = null)
+    public function __construct(BoxInterface $size, bool $relative = null, bool $undefined = null, int $orientation = self::ORIENTATION_NORMAL)
     {
+        if ($orientation < 1 || $orientation > 8) {
+            throw new \InvalidArgumentException('Orientation must be one of the ImageDimensionsInterface::ORIENTATION_* constants');
+        }
+
         if (null === $relative) {
             $relative = $size instanceof RelativeBoxInterface;
         }
@@ -44,6 +53,7 @@ class ImageDimensions implements ImageDimensionsInterface
         }
 
         $this->size = $size;
+        $this->orientation = $orientation;
         $this->relative = $relative;
         $this->undefined = $undefined;
     }
@@ -54,6 +64,14 @@ class ImageDimensions implements ImageDimensionsInterface
     public function getSize(): BoxInterface
     {
         return $this->size;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrientation(): int
+    {
+        return $this->orientation;
     }
 
     /**

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -41,7 +41,9 @@ class ImageDimensions implements ImageDimensionsInterface
     public function __construct(BoxInterface $size, bool $relative = null, bool $undefined = null, int $orientation = self::ORIENTATION_NORMAL)
     {
         if ($orientation < 1 || $orientation > 8) {
-            throw new \InvalidArgumentException('Orientation must be one of the ImageDimensionsInterface::ORIENTATION_* constants');
+            throw new \InvalidArgumentException(
+                'Orientation must be one of the ImageDimensionsInterface::ORIENTATION_* constants'
+            );
         }
 
         if (null === $relative) {

--- a/src/ImageDimensionsInterface.php
+++ b/src/ImageDimensionsInterface.php
@@ -22,9 +22,9 @@ interface ImageDimensionsInterface
      * @see <http://www.cipa.jp/std/documents/e/DC-008-Translation-2019-E.pdf>
      */
     public const ORIENTATION_NORMAL = 1;
-    public const ORIENTATION_NORMAL_90 = 6;
-    public const ORIENTATION_NORMAL_180 = 3;
-    public const ORIENTATION_NORMAL_270 = 8;
+    public const ORIENTATION_90 = 6;
+    public const ORIENTATION_180 = 3;
+    public const ORIENTATION_270 = 8;
     public const ORIENTATION_MIRROR = 2;
     public const ORIENTATION_MIRROR_90 = 7;
     public const ORIENTATION_MIRROR_180 = 4;

--- a/src/ImageDimensionsInterface.php
+++ b/src/ImageDimensionsInterface.php
@@ -16,10 +16,24 @@ use Imagine\Image\BoxInterface;
 
 interface ImageDimensionsInterface
 {
+    public const ORIENTATION_NORMAL = 1;
+    public const ORIENTATION_NORMAL_90 = 6;
+    public const ORIENTATION_NORMAL_180 = 3;
+    public const ORIENTATION_NORMAL_270 = 8;
+    public const ORIENTATION_MIRROR = 2;
+    public const ORIENTATION_MIRROR_90 = 7;
+    public const ORIENTATION_MIRROR_180 = 4;
+    public const ORIENTATION_MIRROR_270 = 5;
+
     /**
      * Returns the size.
      */
     public function getSize(): BoxInterface;
+
+    /**
+     * Returns the orientation flag.
+     */
+    public function getOrientation(): int;
 
     /**
      * Returns the relative flag.

--- a/src/ImageDimensionsInterface.php
+++ b/src/ImageDimensionsInterface.php
@@ -16,6 +16,11 @@ use Imagine\Image\BoxInterface;
 
 interface ImageDimensionsInterface
 {
+    /**
+     * Exif 2.32 orientation attribute (tag 274).
+     *
+     * @see <http://www.cipa.jp/std/documents/e/DC-008-Translation-2019-E.pdf>
+     */
     public const ORIENTATION_NORMAL = 1;
     public const ORIENTATION_NORMAL_90 = 6;
     public const ORIENTATION_NORMAL_180 = 3;

--- a/src/ResizeOptions.php
+++ b/src/ResizeOptions.php
@@ -32,6 +32,11 @@ class ResizeOptions implements ResizeOptionsInterface
     private $bypassCache = false;
 
     /**
+     * @var bool
+     */
+    private $forceReEncoding = false;
+
+    /**
      * {@inheritdoc}
      */
     public function getImagineOptions(): array
@@ -85,6 +90,24 @@ class ResizeOptions implements ResizeOptionsInterface
     public function setBypassCache(bool $bypassCache): ResizeOptionsInterface
     {
         $this->bypassCache = $bypassCache;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getForceReEncoding(): bool
+    {
+        return $this->forceReEncoding;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setForceReEncoding(bool $forceReEncoding): ResizeOptionsInterface
+    {
+        $this->forceReEncoding = $forceReEncoding;
 
         return $this;
     }

--- a/src/ResizeOptions.php
+++ b/src/ResizeOptions.php
@@ -34,7 +34,7 @@ class ResizeOptions implements ResizeOptionsInterface
     /**
      * @var bool
      */
-    private $forceReEncoding = false;
+    private $skipIfDimensionsMatch = true;
 
     /**
      * {@inheritdoc}
@@ -97,17 +97,17 @@ class ResizeOptions implements ResizeOptionsInterface
     /**
      * {@inheritdoc}
      */
-    public function getForceReEncoding(): bool
+    public function getSkipIfDimensionsMatch(): bool
     {
-        return $this->forceReEncoding;
+        return $this->skipIfDimensionsMatch;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setForceReEncoding(bool $forceReEncoding): ResizeOptionsInterface
+    public function setSkipIfDimensionsMatch(bool $skipIfDimensionsMatch): ResizeOptionsInterface
     {
-        $this->forceReEncoding = $forceReEncoding;
+        $this->skipIfDimensionsMatch = $skipIfDimensionsMatch;
 
         return $this;
     }

--- a/src/ResizeOptionsInterface.php
+++ b/src/ResizeOptionsInterface.php
@@ -45,12 +45,12 @@ interface ResizeOptionsInterface
     public function setBypassCache(bool $bypassCache): self;
 
     /**
-     * Returns the force re-encoding flag.
+     * Returns the skip if dimensions match flag.
      */
-    public function getForceReEncoding(): bool;
+    public function getSkipIfDimensionsMatch(): bool;
 
     /**
-     * Sets the force re-encoding flag.
+     * Sets the skip if dimensions match flag.
      */
-    public function setForceReEncoding(bool $forceReEncoding): self;
+    public function setSkipIfDimensionsMatch(bool $skipIfDimensionsMatch): self;
 }

--- a/src/ResizeOptionsInterface.php
+++ b/src/ResizeOptionsInterface.php
@@ -43,4 +43,14 @@ interface ResizeOptionsInterface
      * Sets the bypass cache flag.
      */
     public function setBypassCache(bool $bypassCache): self;
+
+    /**
+     * Returns the force re-encoding flag.
+     */
+    public function getForceReEncoding(): bool;
+
+    /**
+     * Sets the force re-encoding flag.
+     */
+    public function setForceReEncoding(bool $forceReEncoding): self;
 }

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\Image;
 
 use Imagine\Exception\RuntimeException as ImagineRuntimeException;
+use Imagine\Filter\Basic\Autorotate;
 use Imagine\Image\Palette\RGB;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
@@ -58,7 +59,11 @@ class Resizer implements ResizerInterface
      */
     public function resize(ImageInterface $image, ResizeConfigurationInterface $config, ResizeOptionsInterface $options): ImageInterface
     {
-        if ($config->isEmpty() || $image->getDimensions()->isUndefined()) {
+        if (
+            ($config->isEmpty() || $image->getDimensions()->isUndefined())
+            && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
+            && !$options->getForceReEncoding()
+        ) {
             $image = $this->createImage($image, $image->getPath());
         } else {
             $image = $this->processResize($image, $config, $options);
@@ -87,9 +92,13 @@ class Resizer implements ResizerInterface
 
         $imagineOptions = $options->getImagineOptions();
 
-        $imagineImage = $image
-            ->getImagine()
-            ->open($image->getPath())
+        $imagineImage = $image->getImagine()->open($image->getPath());
+
+        if (ImageDimensionsInterface::ORIENTATION_NORMAL !== $image->getDimensions()->getOrientation()) {
+            (new Autorotate())->apply($imagineImage);
+        }
+
+        $imagineImage
             ->resize($coordinates->getSize())
             ->crop($coordinates->getCropStart(), $coordinates->getCropSize())
             ->usePalette(new RGB())
@@ -137,7 +146,12 @@ class Resizer implements ResizerInterface
         $coordinates = $this->calculator->calculate($config, $image->getDimensions(), $image->getImportantPart());
 
         // Skip resizing if it would have no effect
-        if (!$image->getDimensions()->isRelative() && $coordinates->isEqualTo($image->getDimensions()->getSize())) {
+        if (
+            !$image->getDimensions()->isRelative()
+            && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
+            && $coordinates->isEqualTo($image->getDimensions()->getSize())
+            && !$options->getForceReEncoding()
+        ) {
             return $this->createImage($image, $image->getPath());
         }
 

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -62,7 +62,7 @@ class Resizer implements ResizerInterface
         if (
             ($config->isEmpty() || $image->getDimensions()->isUndefined())
             && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
-            && !$options->getForceReEncoding()
+            && $options->getSkipIfDimensionsMatch()
         ) {
             $image = $this->createImage($image, $image->getPath());
         } else {
@@ -150,7 +150,7 @@ class Resizer implements ResizerInterface
             !$image->getDimensions()->isRelative()
             && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
             && $coordinates->isEqualTo($image->getDimensions()->getSize())
-            && !$options->getForceReEncoding()
+            && $options->getSkipIfDimensionsMatch()
         ) {
             return $this->createImage($image, $image->getPath());
         }

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -60,9 +60,9 @@ class Resizer implements ResizerInterface
     public function resize(ImageInterface $image, ResizeConfigurationInterface $config, ResizeOptionsInterface $options): ImageInterface
     {
         if (
-            ($config->isEmpty() || $image->getDimensions()->isUndefined())
+            $options->getSkipIfDimensionsMatch()
             && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
-            && $options->getSkipIfDimensionsMatch()
+            && ($config->isEmpty() || $image->getDimensions()->isUndefined())
         ) {
             $image = $this->createImage($image, $image->getPath());
         } else {
@@ -91,7 +91,6 @@ class Resizer implements ResizerInterface
         }
 
         $imagineOptions = $options->getImagineOptions();
-
         $imagineImage = $image->getImagine()->open($image->getPath());
 
         if (ImageDimensionsInterface::ORIENTATION_NORMAL !== $image->getDimensions()->getOrientation()) {
@@ -147,10 +146,10 @@ class Resizer implements ResizerInterface
 
         // Skip resizing if it would have no effect
         if (
-            !$image->getDimensions()->isRelative()
+            $options->getSkipIfDimensionsMatch()
+            && !$image->getDimensions()->isRelative()
             && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
             && $coordinates->isEqualTo($image->getDimensions()->getSize())
-            && $options->getSkipIfDimensionsMatch()
         ) {
             return $this->createImage($image, $image->getPath());
         }

--- a/tests/ImageDimensionsTest.php
+++ b/tests/ImageDimensionsTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Contao\Image\Tests;
 
 use Contao\Image\ImageDimensions;
+use Contao\Image\ImageDimensionsInterface;
 use Contao\ImagineSvg\RelativeBoxInterface;
 use Contao\ImagineSvg\UndefinedBoxInterface;
 use Imagine\Image\BoxInterface;
@@ -26,6 +27,18 @@ class ImageDimensionsTest extends TestCase
         $dimensions = new ImageDimensions($size);
 
         $this->assertSame($size, $dimensions->getSize());
+    }
+
+    public function testGetOrientation(): void
+    {
+        $size = $this->createMock(BoxInterface::class);
+        $dimensions = new ImageDimensions($size, null, null, ImageDimensionsInterface::ORIENTATION_NORMAL_90);
+
+        $this->assertSame(ImageDimensionsInterface::ORIENTATION_NORMAL_90, $dimensions->getOrientation());
+
+        $this->expectException('InvalidArgumentException');
+
+        new ImageDimensions($size, null, null, 0);
     }
 
     public function testIsRelative(): void

--- a/tests/ImageDimensionsTest.php
+++ b/tests/ImageDimensionsTest.php
@@ -32,9 +32,9 @@ class ImageDimensionsTest extends TestCase
     public function testGetOrientation(): void
     {
         $size = $this->createMock(BoxInterface::class);
-        $dimensions = new ImageDimensions($size, null, null, ImageDimensionsInterface::ORIENTATION_NORMAL_90);
+        $dimensions = new ImageDimensions($size, null, null, ImageDimensionsInterface::ORIENTATION_90);
 
-        $this->assertSame(ImageDimensionsInterface::ORIENTATION_NORMAL_90, $dimensions->getOrientation());
+        $this->assertSame(ImageDimensionsInterface::ORIENTATION_90, $dimensions->getOrientation());
 
         $this->expectException('InvalidArgumentException');
 

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -244,9 +244,9 @@ class ImageTest extends TestCase
     public function getDimensionsFromExifRotated()
     {
         yield [ImageDimensionsInterface::ORIENTATION_NORMAL,     22, 11, 22, 11];
-        yield [ImageDimensionsInterface::ORIENTATION_NORMAL_90,  22, 11, 11, 22];
-        yield [ImageDimensionsInterface::ORIENTATION_NORMAL_180, 22, 11, 22, 11];
-        yield [ImageDimensionsInterface::ORIENTATION_NORMAL_270, 22, 11, 11, 22];
+        yield [ImageDimensionsInterface::ORIENTATION_90,  22, 11, 11, 22];
+        yield [ImageDimensionsInterface::ORIENTATION_180, 22, 11, 22, 11];
+        yield [ImageDimensionsInterface::ORIENTATION_270, 22, 11, 11, 22];
         yield [ImageDimensionsInterface::ORIENTATION_MIRROR,     22, 11, 22, 11];
         yield [ImageDimensionsInterface::ORIENTATION_MIRROR_90,  22, 11, 11, 22];
         yield [ImageDimensionsInterface::ORIENTATION_MIRROR_180, 22, 11, 22, 11];

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -245,12 +245,12 @@ class ImageTest extends TestCase
 
     public function getDimensionsFromExifRotated(): \Generator
     {
-        yield [ImageDimensionsInterface::ORIENTATION_NORMAL,     22, 11, 22, 11];
-        yield [ImageDimensionsInterface::ORIENTATION_90,  22, 11, 11, 22];
+        yield [ImageDimensionsInterface::ORIENTATION_NORMAL, 22, 11, 22, 11];
+        yield [ImageDimensionsInterface::ORIENTATION_90, 22, 11, 11, 22];
         yield [ImageDimensionsInterface::ORIENTATION_180, 22, 11, 22, 11];
         yield [ImageDimensionsInterface::ORIENTATION_270, 22, 11, 11, 22];
-        yield [ImageDimensionsInterface::ORIENTATION_MIRROR,     22, 11, 22, 11];
-        yield [ImageDimensionsInterface::ORIENTATION_MIRROR_90,  22, 11, 11, 22];
+        yield [ImageDimensionsInterface::ORIENTATION_MIRROR, 22, 11, 22, 11];
+        yield [ImageDimensionsInterface::ORIENTATION_MIRROR_90, 22, 11, 11, 22];
         yield [ImageDimensionsInterface::ORIENTATION_MIRROR_180, 22, 11, 22, 11];
         yield [ImageDimensionsInterface::ORIENTATION_MIRROR_270, 22, 11, 11, 22];
     }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -187,6 +187,10 @@ class ImageTest extends TestCase
      */
     public function testGetDimensionsFromExifRotatedFile(int $orientation, int $width, int $height, int $expectedWidth, int $expectedHeight): void
     {
+        if (!\function_exists('exif_read_data')) {
+            $this->markTestSkipped('Your platform is missing the EXIF extension.');
+        }
+
         if (!is_dir($this->rootDir)) {
             mkdir($this->rootDir, 0777, true);
         }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -166,6 +166,7 @@ class ImageTest extends TestCase
             ->method('getSize')
             ->willReturn(new Box(100, 100))
         ;
+
         $imagineImage
             ->method('metadata')
             ->willReturn(new MetadataBag())
@@ -188,7 +189,7 @@ class ImageTest extends TestCase
     public function testGetDimensionsFromExifRotatedFile(int $orientation, int $width, int $height, int $expectedWidth, int $expectedHeight): void
     {
         if (!\function_exists('exif_read_data')) {
-            $this->markTestSkipped('Your platform is missing the EXIF extension.');
+            $this->markTestSkipped('The PHP EXIF extension is not installed');
         }
 
         if (!is_dir($this->rootDir)) {
@@ -221,6 +222,7 @@ class ImageTest extends TestCase
             ->method('getSize')
             ->willReturn(new Box($width, $height))
         ;
+
         $imagineImage
             ->method('metadata')
             ->willReturn(new MetadataBag(['ifd0.Orientation' => $orientation]))
@@ -241,7 +243,7 @@ class ImageTest extends TestCase
         $this->assertSame($orientation, $dimensions->getOrientation());
     }
 
-    public function getDimensionsFromExifRotated()
+    public function getDimensionsFromExifRotated(): \Generator
     {
         yield [ImageDimensionsInterface::ORIENTATION_NORMAL,     22, 11, 22, 11];
         yield [ImageDimensionsInterface::ORIENTATION_90,  22, 11, 11, 22];

--- a/tests/ResizeOptionsTest.php
+++ b/tests/ResizeOptionsTest.php
@@ -52,12 +52,12 @@ class ResizeOptionsTest extends TestCase
         $this->assertTrue($options->getBypassCache());
     }
 
-    public function testSetForceReEncoding(): void
+    public function testSetSkipIfDimensionsMatch(): void
     {
         $options = new ResizeOptions();
 
-        $this->assertFalse($options->getForceReEncoding());
-        $this->assertSame($options, $options->setForceReEncoding(true));
-        $this->assertTrue($options->getForceReEncoding());
+        $this->assertTrue($options->getSkipIfDimensionsMatch());
+        $this->assertSame($options, $options->setSkipIfDimensionsMatch(false));
+        $this->assertFalse($options->getSkipIfDimensionsMatch());
     }
 }

--- a/tests/ResizeOptionsTest.php
+++ b/tests/ResizeOptionsTest.php
@@ -51,4 +51,13 @@ class ResizeOptionsTest extends TestCase
         $this->assertSame($options, $options->setBypassCache(true));
         $this->assertTrue($options->getBypassCache());
     }
+
+    public function testSetForceReEncoding(): void
+    {
+        $options = new ResizeOptions();
+
+        $this->assertFalse($options->getForceReEncoding());
+        $this->assertSame($options, $options->setForceReEncoding(true));
+        $this->assertTrue($options->getForceReEncoding());
+    }
 }

--- a/tests/ResizerTest.php
+++ b/tests/ResizerTest.php
@@ -520,7 +520,7 @@ class ResizerTest extends TestCase
         $image = $this->createMock(Image::class);
         $image
             ->method('getDimensions')
-            ->willReturn(new ImageDimensions(new Box(100, 100), null, null, ImageDimensionsInterface::ORIENTATION_NORMAL_180))
+            ->willReturn(new ImageDimensions(new Box(100, 100), null, null, ImageDimensionsInterface::ORIENTATION_180))
         ;
 
         $image

--- a/tests/ResizerTest.php
+++ b/tests/ResizerTest.php
@@ -545,7 +545,7 @@ class ResizerTest extends TestCase
         $this->assertNotSame($image, $resizedImage);
     }
 
-    public function testResizeEmptyConfigForcedReEncode(): void
+    public function testResizeEmptyConfigNoSkip(): void
     {
         $imagePath = $this->rootDir.'/dummy.jpg';
         $resizer = $this->createResizer();
@@ -583,7 +583,7 @@ class ResizerTest extends TestCase
         ;
 
         $options = new ResizeOptions();
-        $options->setForceReEncoding(true);
+        $options->setSkipIfDimensionsMatch(false);
 
         $resizedImage = $resizer->resize($image, $configuration, $options);
 


### PR DESCRIPTION
As discussed in https://github.com/contao/image/issues/44#issuecomment-499604381 we want to automatically rotate images if they have an EXIF IFD0-Orientation tag.

I also added a `force-re-encoding` flag that might be useful to get the benefits of resizing (like to-RGB-conversion, interlacing, metadata-stripping, sampling factors and specific JPEG-quality) even if no resize is required. (cc @agoat)

### ToDo

- [x] Is `forceReEncoding` the correct name for this flag? `reEncodeImageEvenIfNoResizeIsRequired` seems too long 😉
- [x] Create a pull request for Contao 4.8 to let lightbox images run through the image factory so that they get EXIF rotated too.