### PR TITLE
Add support multiple image formats in pictures

### DIFF
--- a/src/PictureConfiguration.php
+++ b/src/PictureConfiguration.php
@@ -25,6 +25,11 @@ class PictureConfiguration implements PictureConfigurationInterface
     private $sizeItems = [];
 
     /**
+     * @var array[]
+     */
+    private $formats = [];
+
+    /**
      * {@inheritdoc}
      */
     public function getSize(): PictureConfigurationItemInterface
@@ -70,5 +75,50 @@ class PictureConfiguration implements PictureConfigurationInterface
         $this->sizeItems = $sizeItems;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormats(): array
+    {
+        return $this->formats ?: [self::FORMAT_DEFAULT => [self::FORMAT_DEFAULT]];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFormats(array $formats): PictureConfigurationInterface
+    {
+        if (!isset($formats[self::FORMAT_DEFAULT])) {
+            $formats[self::FORMAT_DEFAULT] = [self::FORMAT_DEFAULT];
+        }
+
+        foreach ($formats as $sourceFormat => $targetFormats) {
+            $this->assertValidFormat($sourceFormat);
+            foreach ($targetFormats as $targetFormat) {
+                $this->assertValidFormat($targetFormat);
+            }
+        }
+
+        $this->formats = $formats;
+
+        return $this;
+    }
+
+    /**
+     * Throws an exception on invalid image formats.
+     */
+    private function assertValidFormat(string $format): void
+    {
+        if (self::FORMAT_DEFAULT === $format) {
+            return;
+        }
+
+        if (preg_match('/^[a-z0-9]+$/', $format)) {
+            return;
+        }
+
+        throw new \InvalidArgumentException(sprintf('Invalid image format "%s".', $format));
     }
 }

--- a/src/PictureConfiguration.php
+++ b/src/PictureConfiguration.php
@@ -96,6 +96,7 @@ class PictureConfiguration implements PictureConfigurationInterface
 
         foreach ($formats as $sourceFormat => $targetFormats) {
             $this->assertValidFormat($sourceFormat);
+
             foreach ($targetFormats as $targetFormat) {
                 $this->assertValidFormat($targetFormat);
             }

--- a/src/PictureConfigurationInterface.php
+++ b/src/PictureConfigurationInterface.php
@@ -14,6 +14,8 @@ namespace Contao\Image;
 
 interface PictureConfigurationInterface
 {
+    public const FORMAT_DEFAULT = '.default';
+
     /**
      * Returns the size.
      */
@@ -37,4 +39,18 @@ interface PictureConfigurationInterface
      * @param PictureConfigurationItemInterface[] $sizeItems
      */
     public function setSizeItems(array $sizeItems): self;
+
+    /**
+     * Returns the formats.
+     *
+     * @return array<string,string[]>
+     */
+    public function getFormats(): array;
+
+    /**
+     * Sets the formats.
+     *
+     * @param array<string,string[]> $formats
+     */
+    public function setFormats(array $formats): self;
 }

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -188,7 +188,8 @@ class Resizer implements ResizerInterface
 
         $hash = substr(md5(implode('|', $hashData)), 0, 9);
         $pathinfo = pathinfo($path);
+        $extension = $options->getImagineOptions()['format'] ?? $pathinfo['extension'];
 
-        return $hash[0].'/'.$pathinfo['filename'].'-'.substr($hash, 1).'.'.$pathinfo['extension'];
+        return $hash[0].'/'.$pathinfo['filename'].'-'.substr($hash, 1).'.'.$extension;
     }
 }

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -59,8 +59,11 @@ class Resizer implements ResizerInterface
      */
     public function resize(ImageInterface $image, ResizeConfigurationInterface $config, ResizeOptionsInterface $options): ImageInterface
     {
+        $extension = strtolower(pathinfo($image->getPath(), PATHINFO_EXTENSION));
+
         if (
             $options->getSkipIfDimensionsMatch()
+            && ($options->getImagineOptions()['format'] ?? $extension) === $extension
             && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
             && ($config->isEmpty() || $image->getDimensions()->isUndefined())
         ) {
@@ -143,10 +146,12 @@ class Resizer implements ResizerInterface
     protected function processResize(ImageInterface $image, ResizeConfigurationInterface $config, ResizeOptionsInterface $options): ImageInterface
     {
         $coordinates = $this->calculator->calculate($config, $image->getDimensions(), $image->getImportantPart());
+        $extension = strtolower(pathinfo($image->getPath(), PATHINFO_EXTENSION));
 
         // Skip resizing if it would have no effect
         if (
             $options->getSkipIfDimensionsMatch()
+            && ($options->getImagineOptions()['format'] ?? $extension) === $extension
             && !$image->getDimensions()->isRelative()
             && ImageDimensionsInterface::ORIENTATION_NORMAL === $image->getDimensions()->getOrientation()
             && $coordinates->isEqualTo($image->getDimensions()->getSize())

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -119,6 +119,11 @@ class Resizer implements ResizerInterface
             $imagineOptions['format'] = strtolower(pathinfo($path, PATHINFO_EXTENSION));
         }
 
+        // Fix bug with undefined index notice in Imagine
+        if ('webp' === $imagineOptions['format'] && !isset($imagineOptions['webp_quality'])) {
+            $imagineOptions['webp_quality'] = 80;
+        }
+
         // Atomic write operation
         $tmpPath = $this->filesystem->tempnam($dir, 'img');
         $this->filesystem->chmod($tmpPath, 0666, umask());

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -193,7 +193,7 @@ class Resizer implements ResizerInterface
 
         $hash = substr(md5(implode('|', $hashData)), 0, 9);
         $pathinfo = pathinfo($path);
-        $extension = $options->getImagineOptions()['format'] ?? $pathinfo['extension'];
+        $extension = $options->getImagineOptions()['format'] ?? strtolower($pathinfo['extension']);
 
         return $hash[0].'/'.$pathinfo['filename'].'-'.substr($hash, 1).'.'.$extension;
     }

--- a/tests/PictureGeneratorTest.php
+++ b/tests/PictureGeneratorTest.php
@@ -202,7 +202,7 @@ class PictureGeneratorTest extends TestCase
         $resizer
             ->method('resize')
             ->willReturnCallback(
-                function (ImageInterface $image, ResizeConfigurationInterface $config) {
+                function (ImageInterface $image, ResizeConfigurationInterface $config, ResizeOptionsInterface $options) {
                     $imageMock = $this->createMock(Image::class);
                     $imageMock
                         ->method('getDimensions')
@@ -219,6 +219,8 @@ class PictureGeneratorTest extends TestCase
                         ->willReturn('/dir/image-'.($config->getHeight() * 2).'.jpg')
                     ;
 
+                    $this->assertSame('', $options->getImagineOptions()['format']);
+
                     return $imageMock;
                 }
             )
@@ -233,6 +235,11 @@ class PictureGeneratorTest extends TestCase
         $imageMock
             ->method('getImportantPart')
             ->willReturn(new ImportantPart())
+        ;
+
+        $imageMock
+            ->method('getPath')
+            ->willReturn('/dir/source-image-without-extension')
         ;
 
         $pictureGenerator = $this->createPictureGenerator($resizer);

--- a/tests/PictureGeneratorTest.php
+++ b/tests/PictureGeneratorTest.php
@@ -23,6 +23,7 @@ use Contao\Image\ResizeCalculator;
 use Contao\Image\ResizeConfiguration;
 use Contao\Image\ResizeConfigurationInterface;
 use Contao\Image\ResizeOptions;
+use Contao\Image\ResizeOptionsInterface;
 use Contao\Image\ResizerInterface;
 use Contao\ImagineSvg\Imagine as ImagineSvg;
 use Imagine\Image\Box;
@@ -37,7 +38,9 @@ class PictureGeneratorTest extends TestCase
         $resizer
             ->method('resize')
             ->willReturnCallback(
-                function (ImageInterface $image, ResizeConfigurationInterface $config) {
+                function (ImageInterface $image, ResizeConfigurationInterface $config, ResizeOptionsInterface $options) {
+                    $format = $options->getImagineOptions()['format'];
+
                     $imageMock = $this->createMock(Image::class);
                     $imageMock
                         ->method('getDimensions')
@@ -49,13 +52,15 @@ class PictureGeneratorTest extends TestCase
 
                     $imageMock
                         ->method('getUrl')
-                        ->willReturn('image-'.min(1000, $config->getWidth()).'.jpg')
+                        ->willReturn('image-'.min(1000, $config->getWidth()).'.'.$format)
                     ;
 
                     $imageMock
                         ->method('getPath')
-                        ->willReturn('/dir/image-'.min(1000, $config->getWidth()).'.jpg')
+                        ->willReturn('/dir/image-'.min(1000, $config->getWidth()).'.'.$format)
                     ;
+
+                    $this->assertContains($format, ['jpg', 'webp']);
 
                     return $imageMock;
                 }
@@ -73,9 +78,17 @@ class PictureGeneratorTest extends TestCase
             ->willReturn(new ImportantPart())
         ;
 
+        $imageMock
+            ->method('getPath')
+            ->willReturn('/dir/source-image.jpg')
+        ;
+
         $pictureGenerator = $this->createPictureGenerator($resizer);
 
         $pictureConfig = (new PictureConfiguration())
+            ->setFormats([
+                'jpg' => ['webp', 'jpg'],
+            ])
             ->setSize((new PictureConfigurationItem())
                 ->setDensities('1x, 1.35354x, 1.9999x, 10x')
                 ->setResizeConfig((new ResizeConfiguration())
@@ -125,12 +138,29 @@ class PictureGeneratorTest extends TestCase
         $this->assertSame(
             [
                 [
+                    'srcset' => 'image-100.webp 100w, image-50.webp 50w',
+                    'src' => 'image-100.webp',
+                    'width' => 100,
+                    'height' => 50,
+                    'sizes' => '50vw',
+                    'media' => '(min-width: 600px)',
+                    'type' => 'image/webp',
+                ],
+                [
                     'srcset' => 'image-100.jpg 100w, image-50.jpg 50w',
                     'src' => 'image-100.jpg',
                     'width' => 100,
                     'height' => 50,
                     'sizes' => '50vw',
                     'media' => '(min-width: 600px)',
+                ],
+                [
+                    'srcset' => 'image-50.webp',
+                    'src' => 'image-50.webp',
+                    'width' => 50,
+                    'height' => 25,
+                    'media' => '(min-width: 300px)',
+                    'type' => 'image/webp',
                 ],
                 [
                     'srcset' => 'image-50.jpg',
@@ -140,11 +170,26 @@ class PictureGeneratorTest extends TestCase
                     'media' => '(min-width: 300px)',
                 ],
                 [
+                    'srcset' => 'image-160.webp 1x, image-1000.webp 6.25x',
+                    'src' => 'image-160.webp',
+                    'width' => 160,
+                    'height' => 160,
+                    'media' => '(min-width: 200px)',
+                    'type' => 'image/webp',
+                ],
+                [
                     'srcset' => 'image-160.jpg 1x, image-1000.jpg 6.25x',
                     'src' => 'image-160.jpg',
                     'width' => 160,
                     'height' => 160,
                     'media' => '(min-width: 200px)',
+                ],
+                [
+                    'srcset' => 'image-99.webp 1x, image-134.webp 1.354x, image-198.webp 2x, image-990.webp 10x',
+                    'src' => 'image-99.webp',
+                    'width' => 99,
+                    'height' => 99,
+                    'type' => 'image/webp',
                 ],
             ],
             $picture->getSources('/root/dir')

--- a/tests/ResizerTest.php
+++ b/tests/ResizerTest.php
@@ -454,6 +454,55 @@ class ResizerTest extends TestCase
         $this->assertNotSame($image, $resizedImage);
     }
 
+    public function testResizeEmptyConfigWithFormat(): void
+    {
+        $imagePath = $this->rootDir.'/dummy.jpg';
+        $resizer = $this->createResizer();
+
+        if (!is_dir($this->rootDir)) {
+            mkdir($this->rootDir, 0777, true);
+        }
+
+        (new GdImagine())
+            ->create(new Box(100, 100))
+            ->save($imagePath)
+        ;
+
+        /** @var Image|MockObject $image */
+        $image = $this->createMock(Image::class);
+        $image
+            ->method('getDimensions')
+            ->willReturn(new ImageDimensions(new Box(100, 100)))
+        ;
+
+        $image
+            ->method('getPath')
+            ->willReturn($imagePath)
+        ;
+
+        $image
+            ->method('getImagine')
+            ->willReturn(new GdImagine())
+        ;
+
+        $configuration = $this->createMock(ResizeConfigurationInterface::class);
+        $configuration
+            ->method('isEmpty')
+            ->willReturn(true)
+        ;
+
+        $resizedImage = $resizer->resize(
+            $image,
+            $configuration,
+            (new ResizeOptions())
+                ->setSkipIfDimensionsMatch(true)
+                ->setImagineOptions(['format' => 'png'])
+        );
+
+        $this->assertRegExp('(/[0-9a-f]/dummy-[0-9a-f]{8}.png$)', $resizedImage->getPath());
+        $this->assertNotSame($image, $resizedImage);
+    }
+
     public function testResizeSameDimensions(): void
     {
         $path = $this->rootDir.'/dummy.jpg';


### PR DESCRIPTION
This pull request adds the possibility to use mutiple image formats and convert them automatically. 

Examples:

```php
// Convert bitmap images to JPEG and GIFs to PNGs
->setFormats([
    'bmp' => ['jpg'],
    'gif' => ['png'],
])

// Convert JPEG and WEBP images to one another to save bandwith on modern browsers
->setFormats([
    'jpg' => ['webp', 'jpg'],
    'webp' => ['webp', 'jpg'],
])
```

Related: avalanche123/Imagine#718