### PR TITLE
Add namespaced exceptions and a specific FileNotExistsException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+* Add namespaced exceptions and a specific `FileNotExistsException`. [#79]
 
 ## [1.0.3] (2020-11-20)
 
@@ -140,6 +141,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.2.0]: https://github.com/contao/image/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/contao/image/commits/0.1.0
 
+[#79]: https://github.com/contao/image/issues/79
 [#74]: https://github.com/contao/image/issues/74
 [#71]: https://github.com/contao/image/issues/71
 [#70]: https://github.com/contao/image/issues/70

--- a/src/DeferredResizer.php
+++ b/src/DeferredResizer.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
+use Contao\Image\Exception\RuntimeException;
 use Imagine\Image\Box;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Point;
@@ -78,7 +80,7 @@ class DeferredResizer extends Resizer implements DeferredResizerInterface
     public function resizeDeferredImage(DeferredImageInterface $image, bool $blocking = true): ?ImageInterface
     {
         if (!Path::isBasePath($this->cacheDir, $image->getPath())) {
-            throw new \InvalidArgumentException(sprintf('Path "%s" is not inside cache directory "%s"', $image->getPath(), $this->cacheDir));
+            throw new InvalidArgumentException(sprintf('Path "%s" is not inside cache directory "%s"', $image->getPath(), $this->cacheDir));
         }
 
         $targetPath = Path::makeRelative($image->getPath(), $this->cacheDir);
@@ -96,7 +98,7 @@ class DeferredResizer extends Resizer implements DeferredResizerInterface
 
         if (null === $config) {
             if ($blocking) {
-                throw new \RuntimeException(sprintf('Unable to acquire lock for "%s"', $targetPath));
+                throw new RuntimeException(sprintf('Unable to acquire lock for "%s"', $targetPath));
             }
 
             return null;

--- a/src/Exception/CoordinatesOutOfBoundsException.php
+++ b/src/Exception/CoordinatesOutOfBoundsException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\Image\Exception;
+
+class CoordinatesOutOfBoundsException extends InvalidArgumentException
+{
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\Image\Exception;
+
+/**
+ * Exception interface for all exceptions thrown by this library.
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Exception/FileNotExistsException.php
+++ b/src/Exception/FileNotExistsException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\Image\Exception;
+
+class FileNotExistsException extends InvalidArgumentException
+{
+}

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\Image\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Exception/JsonException.php
+++ b/src/Exception/JsonException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\Image\Exception;
+
+class JsonException extends \JsonException implements ExceptionInterface
+{
+}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Contao.
+ *
+ * (c) Leo Feyer
+ *
+ * @license LGPL-3.0-or-later
+ */
+
+namespace Contao\Image\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Image.php
+++ b/src/Image.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\FileNotExistsException;
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\ImagineSvg\Image as SvgImage;
 use Contao\ImagineSvg\Imagine as SvgImagine;
 use DOMDocument;
@@ -58,11 +60,11 @@ class Image implements ImageInterface
         }
 
         if (!$filesystem->exists($path)) {
-            throw new \InvalidArgumentException($path.' does not exist');
+            throw new FileNotExistsException($path.' does not exist');
         }
 
         if (is_dir($path)) {
-            throw new \InvalidArgumentException($path.' is a directory');
+            throw new FileNotExistsException($path.' is a directory');
         }
 
         $this->path = $path;
@@ -91,7 +93,7 @@ class Image implements ImageInterface
     public function getUrl(string $rootDir, string $prefix = ''): string
     {
         if (!Path::isBasePath($rootDir, $this->path)) {
-            throw new \InvalidArgumentException(sprintf('Path "%s" is not inside root directory "%s"', $this->path, $rootDir));
+            throw new InvalidArgumentException(sprintf('Path "%s" is not inside root directory "%s"', $this->path, $rootDir));
         }
 
         $url = Path::makeRelative($this->path, $rootDir);

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\ImagineSvg\RelativeBoxInterface;
 use Contao\ImagineSvg\SvgBox;
 use Contao\ImagineSvg\UndefinedBoxInterface;
@@ -56,7 +57,7 @@ class ImageDimensions
     public function __construct(BoxInterface $size, bool $relative = null, bool $undefined = null, int $orientation = self::ORIENTATION_NORMAL)
     {
         if ($orientation < 1 || $orientation > 8) {
-            throw new \InvalidArgumentException('Orientation must be one of the ImageDimensions::ORIENTATION_* constants');
+            throw new InvalidArgumentException('Orientation must be one of the ImageDimensions::ORIENTATION_* constants');
         }
 
         if (null === $relative) {

--- a/src/ImportantPart.php
+++ b/src/ImportantPart.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
+
 class ImportantPart
 {
     /**
@@ -42,12 +44,12 @@ class ImportantPart
     public function __construct(float $x = 0, float $y = 0, float $width = 1, float $height = 1)
     {
         if ($x < 0 || $x > 1 || $y < 0 || $y > 1 || $width < 0 || $width > 1 || $height < 0 || $height > 1) {
-            throw new \InvalidArgumentException('X, Y, width and height must be a float between 0 and 1');
+            throw new InvalidArgumentException('X, Y, width and height must be a float between 0 and 1');
         }
 
         if ($x + $width > 1) {
             if ($x + $width - 1 > self::ROUNDING_ERROR_THRESHOLD) {
-                throw new \InvalidArgumentException('The X coordinate plus the width must not be greater than 1');
+                throw new InvalidArgumentException('The X coordinate plus the width must not be greater than 1');
             }
 
             $width = 1 - $x;
@@ -55,7 +57,7 @@ class ImportantPart
 
         if ($y + $height > 1) {
             if ($y + $height - 1 > self::ROUNDING_ERROR_THRESHOLD) {
-                throw new \InvalidArgumentException('The Y coordinate plus the height must not be greater than 1');
+                throw new InvalidArgumentException('The Y coordinate plus the height must not be greater than 1');
             }
 
             $height = 1 - $y;

--- a/src/ImportantPart.php
+++ b/src/ImportantPart.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
-use Contao\Image\Exception\InvalidArgumentException;
+use Contao\Image\Exception\CoordinatesOutOfBoundsException;
 
 class ImportantPart
 {
@@ -44,12 +44,12 @@ class ImportantPart
     public function __construct(float $x = 0, float $y = 0, float $width = 1, float $height = 1)
     {
         if ($x < 0 || $x > 1 || $y < 0 || $y > 1 || $width < 0 || $width > 1 || $height < 0 || $height > 1) {
-            throw new InvalidArgumentException('X, Y, width and height must be a float between 0 and 1');
+            throw new CoordinatesOutOfBoundsException('X, Y, width and height must be a float between 0 and 1');
         }
 
         if ($x + $width > 1) {
             if ($x + $width - 1 > self::ROUNDING_ERROR_THRESHOLD) {
-                throw new InvalidArgumentException('The X coordinate plus the width must not be greater than 1');
+                throw new CoordinatesOutOfBoundsException('The X coordinate plus the width must not be greater than 1');
             }
 
             $width = 1 - $x;
@@ -57,7 +57,7 @@ class ImportantPart
 
         if ($y + $height > 1) {
             if ($y + $height - 1 > self::ROUNDING_ERROR_THRESHOLD) {
-                throw new InvalidArgumentException('The Y coordinate plus the height must not be greater than 1');
+                throw new CoordinatesOutOfBoundsException('The Y coordinate plus the height must not be greater than 1');
             }
 
             $height = 1 - $y;

--- a/src/Picture.php
+++ b/src/Picture.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
+
 class Picture implements PictureInterface
 {
     /**
@@ -44,7 +46,7 @@ class Picture implements PictureInterface
     {
         if (null === $rootDir) {
             if ('' !== $prefix) {
-                throw new \InvalidArgumentException(sprintf('Prefix must no be specified if rootDir is null, given "%s"', $prefix));
+                throw new InvalidArgumentException(sprintf('Prefix must no be specified if rootDir is null, given "%s"', $prefix));
             }
 
             return $this->img;
@@ -60,7 +62,7 @@ class Picture implements PictureInterface
     {
         if (null === $rootDir) {
             if ('' !== $prefix) {
-                throw new \InvalidArgumentException(sprintf('Prefix must no be specified if rootDir is null, given "%s"', $prefix));
+                throw new InvalidArgumentException(sprintf('Prefix must no be specified if rootDir is null, given "%s"', $prefix));
             }
 
             return $this->sources;
@@ -104,11 +106,11 @@ class Picture implements PictureInterface
     private function validateSrcAttribute(array $img): void
     {
         if (!isset($img['src'])) {
-            throw new \InvalidArgumentException('Missing src attribute');
+            throw new InvalidArgumentException('Missing src attribute');
         }
 
         if (!$img['src'] instanceof ImageInterface) {
-            throw new \InvalidArgumentException('Src must be of type ImageInterface');
+            throw new InvalidArgumentException('Src must be of type ImageInterface');
         }
     }
 
@@ -118,12 +120,12 @@ class Picture implements PictureInterface
     private function validateSrcsetAttribute(array $img): void
     {
         if (!isset($img['srcset'])) {
-            throw new \InvalidArgumentException('Missing srcset attribute');
+            throw new InvalidArgumentException('Missing srcset attribute');
         }
 
         foreach ($img['srcset'] as $src) {
             if (!$src[0] instanceof ImageInterface) {
-                throw new \InvalidArgumentException('Srcsets must be of type ImageInterface');
+                throw new InvalidArgumentException('Srcsets must be of type ImageInterface');
             }
         }
     }

--- a/src/PictureConfiguration.php
+++ b/src/PictureConfiguration.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
+
 class PictureConfiguration
 {
     public const FORMAT_DEFAULT = '.default';
@@ -62,7 +64,7 @@ class PictureConfiguration
     {
         foreach ($sizeItems as $sizeItem) {
             if (!$sizeItem instanceof PictureConfigurationItem) {
-                throw new \InvalidArgumentException('$sizeItems must be an array of PictureConfigurationItem objects');
+                throw new InvalidArgumentException('$sizeItems must be an array of PictureConfigurationItem objects');
             }
         }
 
@@ -114,6 +116,6 @@ class PictureConfiguration
             return;
         }
 
-        throw new \InvalidArgumentException(sprintf('Invalid image format "%s".', $format));
+        throw new InvalidArgumentException(sprintf('Invalid image format "%s".', $format));
     }
 }

--- a/src/ResizeCalculator.php
+++ b/src/ResizeCalculator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Imagine\Image\Box;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Point;
@@ -38,7 +39,7 @@ class ResizeCalculator
                     return $this->calculateBox($widthHeight, $dimensions, $importantPartArray, $zoom);
             }
 
-            throw new \InvalidArgumentException(sprintf('Unsupported resize mode "%s"', $config->getMode()));
+            throw new InvalidArgumentException(sprintf('Unsupported resize mode "%s"', $config->getMode()));
         }
 
         // If no dimensions are specified, use the zoomed important part

--- a/src/ResizeConfiguration.php
+++ b/src/ResizeConfiguration.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
+
 class ResizeConfiguration
 {
     public const MODE_CROP = 'crop';
@@ -54,7 +56,7 @@ class ResizeConfiguration
     public function setWidth(int $width): self
     {
         if ($width < 0) {
-            throw new \InvalidArgumentException('Width must not be negative');
+            throw new InvalidArgumentException('Width must not be negative');
         }
 
         $this->width = $width;
@@ -70,7 +72,7 @@ class ResizeConfiguration
     public function setHeight(int $height): self
     {
         if ($height < 0) {
-            throw new \InvalidArgumentException('Height must not be negative');
+            throw new InvalidArgumentException('Height must not be negative');
         }
 
         $this->height = $height;
@@ -92,7 +94,7 @@ class ResizeConfiguration
     public function setMode(string $mode): self
     {
         if (!\in_array($mode, [self::MODE_CROP, self::MODE_BOX, self::MODE_PROPORTIONAL], true)) {
-            throw new \InvalidArgumentException('Mode must be one of the '.self::class.'::MODE_* constants');
+            throw new InvalidArgumentException('Mode must be one of the '.self::class.'::MODE_* constants');
         }
 
         $this->mode = $mode;
@@ -108,7 +110,7 @@ class ResizeConfiguration
     public function setZoomLevel(int $zoomLevel): self
     {
         if ($zoomLevel < 0 || $zoomLevel > 100) {
-            throw new \InvalidArgumentException('Zoom level must be between 0 and 100');
+            throw new InvalidArgumentException('Zoom level must be between 0 and 100');
         }
 
         $this->zoomLevel = $zoomLevel;

--- a/src/ResizeCoordinates.php
+++ b/src/ResizeCoordinates.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Point;
 use Imagine\Image\PointInterface;
@@ -79,7 +80,7 @@ class ResizeCoordinates
         }
 
         if (!$coordinates instanceof self) {
-            throw new \InvalidArgumentException(sprintf('$coordinates must be an instance of ResizeCoordinates or BoxInterface, "%s" given', \get_class($coordinates)));
+            throw new InvalidArgumentException(sprintf('$coordinates must be an instance of ResizeCoordinates or BoxInterface, "%s" given', \get_class($coordinates)));
         }
 
         /** @var self $coordinates */

--- a/src/ResizeCoordinates.php
+++ b/src/ResizeCoordinates.php
@@ -75,6 +75,7 @@ class ResizeCoordinates
      */
     public function isEqualTo($coordinates): bool
     {
+        /** @var BoxInterface $coordinates */
         if ($coordinates instanceof BoxInterface) {
             $coordinates = new self($coordinates, new Point(0, 0), $coordinates);
         }

--- a/src/ResizeOptions.php
+++ b/src/ResizeOptions.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Symfony\Component\Filesystem\Filesystem;
 
 class ResizeOptions
@@ -56,7 +57,7 @@ class ResizeOptions
     public function setTargetPath(?string $targetPath): self
     {
         if (null !== $targetPath && !(new Filesystem())->isAbsolutePath($targetPath)) {
-            throw new \InvalidArgumentException('"'.$targetPath.'" is not an absolute target path');
+            throw new InvalidArgumentException('"'.$targetPath.'" is not an absolute target path');
         }
 
         $this->targetPath = $targetPath;

--- a/tests/DeferredImageStorageFilesystemTest.php
+++ b/tests/DeferredImageStorageFilesystemTest.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 namespace Contao\Image\Tests;
 
 use Contao\Image\DeferredImageStorageFilesystem;
+use Contao\Image\Exception\InvalidArgumentException;
+use Contao\Image\Exception\JsonException;
+use Contao\Image\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -109,7 +112,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
 
         $storage->releaseLock($key);
 
-        $this->expectException('RuntimeException');
+        $this->expectException(RuntimeException::class);
 
         $storage->releaseLock($key);
     }
@@ -131,7 +134,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
         }
         file_put_contents($this->rootDir.'/deferred/test.json', 'invalid JSON');
 
-        $this->expectException('JsonException');
+        $this->expectException(JsonException::class);
 
         $storage->get('test');
     }
@@ -145,7 +148,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
         }
         file_put_contents($this->rootDir.'/deferred/test.json', '"JSON string instead of an array"');
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $storage->get('test');
     }
@@ -154,7 +157,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
     {
         $storage = new DeferredImageStorageFilesystem($this->rootDir);
 
-        $this->expectException('JsonException');
+        $this->expectException(JsonException::class);
 
         $storage->set('foo', ["foo\x80bar"]);
     }
@@ -166,7 +169,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
     {
         $storage = new DeferredImageStorageFilesystem($this->rootDir);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $storage->set($key, []);
     }

--- a/tests/DeferredResizerTest.php
+++ b/tests/DeferredResizerTest.php
@@ -15,6 +15,9 @@ namespace Contao\Image\Tests;
 use Contao\Image\DeferredImageInterface;
 use Contao\Image\DeferredImageStorageInterface;
 use Contao\Image\DeferredResizer;
+use Contao\Image\Exception\FileNotExistsException;
+use Contao\Image\Exception\InvalidArgumentException;
+use Contao\Image\Exception\RuntimeException;
 use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImportantPart;
@@ -230,7 +233,7 @@ class DeferredResizerTest extends TestCase
             ->willReturn($this->rootDir.'/../foo.jpg')
         ;
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $resizer->resizeDeferredImage($deferredImage);
     }
 
@@ -293,7 +296,7 @@ class DeferredResizerTest extends TestCase
             ->willReturn($this->rootDir.'/foo.jpg')
         ;
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $resizer->resizeDeferredImage($deferredImage, true);
     }
 
@@ -338,7 +341,7 @@ class DeferredResizerTest extends TestCase
             ->willReturn($this->rootDir.'/foo.jpg')
         ;
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $resizer->resizeDeferredImage($deferredImage);
     }
 

--- a/tests/ImageDimensionsTest.php
+++ b/tests/ImageDimensionsTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\ImageDimensions;
 use Contao\ImagineSvg\RelativeBoxInterface;
 use Contao\ImagineSvg\SvgBox;
@@ -36,7 +37,7 @@ class ImageDimensionsTest extends TestCase
 
         $this->assertSame(ImageDimensions::ORIENTATION_90, $dimensions->getOrientation());
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         new ImageDimensions($size, null, null, 0);
     }

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\FileNotExistsException;
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImportantPart;
@@ -57,14 +59,14 @@ class ImageTest extends TestCase
 
     public function testConstructorNonExistentPath(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(FileNotExistsException::class);
 
         new Image('/path/to/non/existent/file.jpg', $this->createMock(ImagineInterface::class));
     }
 
     public function testConstructorDirPath(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(FileNotExistsException::class);
         $this->createImage(__DIR__);
     }
 
@@ -76,7 +78,7 @@ class ImageTest extends TestCase
             ->willReturn(false)
         ;
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(FileNotExistsException::class);
         $this->createImage(null, null, $filesystem);
     }
 
@@ -103,7 +105,7 @@ class ImageTest extends TestCase
         $this->assertSame('a/filename%20with%20special%26%3C%3E%22%27%252Fchars.jpeg', $image->getUrl('/path/to'));
         $this->assertSame('filename%20with%20special%26%3C%3E%22%27%252Fchars.jpeg', $image->getUrl('/path/to/a'));
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $image->getUrl('/path/t');
     }
@@ -153,7 +155,7 @@ class ImageTest extends TestCase
 
         $image = $this->createImage('C:\path/subdir\..\to\a/file.png');
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $image->getUrl('C:\path/subdir');
     }

--- a/tests/ImportantPartTest.php
+++ b/tests/ImportantPartTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\ImportantPart;
 use PHPUnit\Framework\TestCase;
 
@@ -39,7 +40,7 @@ class ImportantPartTest extends TestCase
      */
     public function testInvalidValuesThrowsException(float $x, float $y, float $width, float $height, string $message): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/'.$message.'/i');
 
         new ImportantPart($x, $y, $width, $height);

--- a/tests/ImportantPartTest.php
+++ b/tests/ImportantPartTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
-use Contao\Image\Exception\InvalidArgumentException;
+use Contao\Image\Exception\CoordinatesOutOfBoundsException;
 use Contao\Image\ImportantPart;
 use PHPUnit\Framework\TestCase;
 
@@ -40,7 +40,7 @@ class ImportantPartTest extends TestCase
      */
     public function testInvalidValuesThrowsException(float $x, float $y, float $width, float $height, string $message): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(CoordinatesOutOfBoundsException::class);
         $this->expectExceptionMessageMatches('/'.$message.'/i');
 
         new ImportantPart($x, $y, $width, $height);

--- a/tests/PictureConfigurationItemTest.php
+++ b/tests/PictureConfigurationItemTest.php
@@ -23,6 +23,7 @@ class PictureConfigurationItemTest extends TestCase
         $config = new PictureConfigurationItem();
         $resizeConfig = $this->createMock(ResizeConfiguration::class);
 
+        $this->assertTrue($config->getResizeConfig()->isEmpty());
         $this->assertSame($config, $config->setResizeConfig($resizeConfig));
         $this->assertSame($resizeConfig, $config->getResizeConfig());
     }

--- a/tests/PictureConfigurationTest.php
+++ b/tests/PictureConfigurationTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\PictureConfiguration;
 use Contao\Image\PictureConfigurationItem;
 use PHPUnit\Framework\TestCase;
@@ -36,7 +37,7 @@ class PictureConfigurationTest extends TestCase
         $this->assertSame($config, $config->setSizeItems([$configItem]));
         $this->assertSame([$configItem], $config->getSizeItems());
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         /** @psalm-suppress InvalidArgument */
         $config->setSizeItems([$configItem, 'not a PictureConfigurationItem']);

--- a/tests/PictureConfigurationTest.php
+++ b/tests/PictureConfigurationTest.php
@@ -42,4 +42,49 @@ class PictureConfigurationTest extends TestCase
         /** @psalm-suppress InvalidArgument */
         $config->setSizeItems([$configItem, 'not a PictureConfigurationItem']);
     }
+
+    public function testSetFormats(): void
+    {
+        $config = new PictureConfiguration();
+
+        $this->assertSame(
+            [PictureConfiguration::FORMAT_DEFAULT => [PictureConfiguration::FORMAT_DEFAULT]],
+            $config->getFormats()
+        );
+
+        $formats = ['png' => ['webp', 'png'], 'jpeg' => ['heic']];
+        $expected = $formats + [PictureConfiguration::FORMAT_DEFAULT => [PictureConfiguration::FORMAT_DEFAULT]];
+
+        $this->assertSame($config, $config->setFormats($formats));
+        $this->assertSame($expected, $config->getFormats());
+
+        $formats = ['png' => ['webp', 'png'], PictureConfiguration::FORMAT_DEFAULT => ['heic']];
+        $expected = $formats;
+
+        $this->assertSame($config, $config->setFormats($formats));
+        $this->assertSame($expected, $config->getFormats());
+
+        $this->assertSame($config, $config->setFormats([]));
+
+        $this->assertSame(
+            [PictureConfiguration::FORMAT_DEFAULT => [PictureConfiguration::FORMAT_DEFAULT]],
+            $config->getFormats()
+        );
+    }
+
+    public function testSetFormatsThrowsForInvalidSourceFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"not-valid"');
+
+        (new PictureConfiguration())->setFormats(['not-valid' => ['png']]);
+    }
+
+    public function testSetFormatsThrowsForInvalidTargetFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"not-valid"');
+
+        (new PictureConfiguration())->setFormats(['png' => ['not-valid']]);
+    }
 }

--- a/tests/PictureTest.php
+++ b/tests/PictureTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\Image;
 use Contao\Image\ImageInterface;
 use Contao\Image\Picture;
@@ -82,7 +83,7 @@ class PictureTest extends TestCase
         $this->assertSame('custom attribute', $picture->getImg()['data-custom']);
         $this->assertSame('custom attribute', $picture->getImg('/')['data-custom']);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $picture->getImg(null, 'https://example.com/images/');
     }
@@ -121,21 +122,21 @@ class PictureTest extends TestCase
         $this->assertSame('custom attribute', $picture->getSources()[0]['data-custom']);
         $this->assertSame('custom attribute', $picture->getSources('/')[0]['data-custom']);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $picture->getSources(null, 'https://example.com/images/');
     }
 
     public function testMissingSrc(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         new Picture(['srcset' => []], []);
     }
 
     public function testInvalidSrc(): void
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         new Picture(['src' => new \stdClass(), 'srcset' => []], []);
     }
@@ -144,7 +145,7 @@ class PictureTest extends TestCase
     {
         $image = $this->createMock(ImageInterface::class);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         new Picture(['src' => $image], []);
     }
@@ -153,7 +154,7 @@ class PictureTest extends TestCase
     {
         $image = $this->createMock(ImageInterface::class);
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         new Picture(['src' => $image, 'srcset' => [[$image, '1x'], [new \stdClass(), '2x']]], []);
     }

--- a/tests/ResizeCalculatorTest.php
+++ b/tests/ResizeCalculatorTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImportantPart;
 use Contao\Image\ResizeCalculator;
@@ -753,7 +754,7 @@ class ResizeCalculatorTest extends TestCase
 
         $dimensions = new ImageDimensions(new Box(100, 100));
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $calculator->calculate($config, $dimensions);
     }

--- a/tests/ResizeConfigurationTest.php
+++ b/tests/ResizeConfigurationTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\ResizeConfiguration;
 use PHPUnit\Framework\TestCase;
 
@@ -64,7 +65,7 @@ class ResizeConfigurationTest extends TestCase
         $this->assertSame($config, $config->setWidth(100));
         $this->assertSame(100, $config->getWidth());
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $config->setWidth(-1);
     }
@@ -77,7 +78,7 @@ class ResizeConfigurationTest extends TestCase
         $this->assertSame($config, $config->setHeight(100));
         $this->assertSame(100, $config->getHeight());
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $config->setHeight(-1);
     }
@@ -90,7 +91,7 @@ class ResizeConfigurationTest extends TestCase
         $this->assertSame($config, $config->setMode(ResizeConfiguration::MODE_BOX));
         $this->assertSame(ResizeConfiguration::MODE_BOX, $config->getMode());
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $config->setMode('invalid');
     }
@@ -103,7 +104,7 @@ class ResizeConfigurationTest extends TestCase
         $this->assertSame($config, $config->setZoomLevel(100));
         $this->assertSame(100, $config->getZoomLevel());
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $config->setZoomLevel(-1);
     }
@@ -112,7 +113,7 @@ class ResizeConfigurationTest extends TestCase
     {
         $config = new ResizeConfiguration();
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $config->setZoomLevel(101);
     }

--- a/tests/ResizeCoordinatesTest.php
+++ b/tests/ResizeCoordinatesTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\ResizeCoordinates;
 use Imagine\Image\Box;
 use Imagine\Image\BoxInterface;
@@ -69,7 +70,7 @@ class ResizeCoordinatesTest extends TestCase
 
         $this->assertTrue($coordinates->isEqualTo(new Box(100, 100)));
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         /** @psalm-suppress InvalidArgument */
         $coordinates->isEqualTo(new \stdClass());

--- a/tests/ResizeOptionsTest.php
+++ b/tests/ResizeOptionsTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Image\Tests;
 
+use Contao\Image\Exception\InvalidArgumentException;
 use Contao\Image\ResizeOptions;
 use PHPUnit\Framework\TestCase;
 
@@ -38,7 +39,7 @@ class ResizeOptionsTest extends TestCase
 
         $this->assertNull($options->getTargetPath());
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $options->setTargetPath('invalid/relative/path');
     }


### PR DESCRIPTION
This should be a better usage of exceptions in the whole library. Now every exception that the library throws implements the `Contao\Image\Exception\ExceptionInterface`.

This is required in order to fix https://github.com/contao/contao/issues/1995#issuecomment-697168755