### PR TITLE
Coding Style

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,12 +2,18 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitExpectationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__.'/tools/ecs/vendor/contao/easy-coding-standard/config/set/contao.php');
+
+    $services = $containerConfigurator->services();
+
+    // Arrow functions require at least PHP 7.4
+    $services->remove(UseArrowFunctionsFixer::class);
 
     $parameters = $containerConfigurator->parameters();
 

--- a/src/Image.php
+++ b/src/Image.php
@@ -16,14 +16,12 @@ use Contao\Image\Exception\FileNotExistsException;
 use Contao\Image\Exception\InvalidArgumentException;
 use Contao\ImagineSvg\Image as SvgImage;
 use Contao\ImagineSvg\Imagine as SvgImagine;
-use DOMDocument;
 use Imagine\Image\Box;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Metadata\MetadataBag;
 use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
-use XMLReader;
 
 class Image implements ImageInterface
 {
@@ -206,14 +204,14 @@ class Image implements ImageInterface
      */
     private function getSvgSize(): ?BoxInterface
     {
-        if (!class_exists(SvgImage::class) || !class_exists(XMLReader::class) || !class_exists(DOMDocument::class)) {
+        if (!class_exists(SvgImage::class) || !class_exists(\XMLReader::class) || !class_exists(\DOMDocument::class)) {
             return null;
         }
 
         static $zlibSupport;
 
         if (null === $zlibSupport) {
-            $reader = new XMLReader();
+            $reader = new \XMLReader();
             $zlibSupport = \in_array('compress.zlib', stream_get_wrappers(), true)
                 && true === @$reader->open('compress.zlib://data:text/xml,<x/>')
                 && true === @$reader->read()
@@ -221,7 +219,7 @@ class Image implements ImageInterface
         }
 
         $size = null;
-        $reader = new XMLReader();
+        $reader = new \XMLReader();
         $path = $this->path;
 
         if ($zlibSupport) {
@@ -262,16 +260,16 @@ class Image implements ImageInterface
     /**
      * Extracts the SVG image size from the given XMLReader object.
      */
-    private function getSvgSizeFromReader(XMLReader $reader): ?BoxInterface
+    private function getSvgSizeFromReader(\XMLReader $reader): ?BoxInterface
     {
         // Move the pointer to the first element in the document
-        while ($reader->read() && XMLReader::ELEMENT !== $reader->nodeType);
+        while ($reader->read() && \XMLReader::ELEMENT !== $reader->nodeType);
 
-        if (XMLReader::ELEMENT !== $reader->nodeType || 'svg' !== $reader->name) {
+        if (\XMLReader::ELEMENT !== $reader->nodeType || 'svg' !== $reader->name) {
             return null;
         }
 
-        $document = new DOMDocument();
+        $document = new \DOMDocument();
         $svg = $document->createElement('svg');
         $document->appendChild($svg);
 

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -18,7 +18,6 @@ use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
 use Contao\Image\ImportantPart;
 use Contao\ImagineSvg\Imagine;
-use Exception;
 use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
@@ -335,7 +334,7 @@ class ImageTest extends TestCase
         $imagine = $this->createMock(Imagine::class);
         $imagine
             ->method('open')
-            ->willThrowException(new Exception())
+            ->willThrowException(new \Exception())
         ;
 
         $image = $this->createImage($this->rootDir.'/dummy.svg', $imagine);

--- a/tests/PhpunitExtension/DeprecatedClasses.php
+++ b/tests/PhpunitExtension/DeprecatedClasses.php
@@ -30,12 +30,12 @@ final class DeprecatedClasses extends DeprecatedClassesPhpunitExtension
 
         if (\PHP_VERSION_ID >= 80100) {
             $deprecations[MetadataBag::class] = [
-                '%s::offsetExists%s#[ReturnTypeWillChange]%s',
-                '%s::offsetGet%s#[ReturnTypeWillChange]%s',
-                '%s::offsetSet%s#[ReturnTypeWillChange]%s',
-                '%s::offsetUnset%s#[ReturnTypeWillChange]%s',
-                '%s::getIterator%s#[ReturnTypeWillChange]%s',
-                '%s::count%s#[ReturnTypeWillChange]%s',
+                '%s::offsetExists%s#[\ReturnTypeWillChange]%s',
+                '%s::offsetGet%s#[\ReturnTypeWillChange]%s',
+                '%s::offsetSet%s#[\ReturnTypeWillChange]%s',
+                '%s::offsetUnset%s#[\ReturnTypeWillChange]%s',
+                '%s::getIterator%s#[\ReturnTypeWillChange]%s',
+                '%s::count%s#[\ReturnTypeWillChange]%s',
             ];
         }
 


### PR DESCRIPTION
I adjusted the config, because we cannot use the `UseArrowFunctionsFixerAlias::class` until we support at least PHP 7.4. 