### PR TITLE
Switch to Symfony's version of the Path helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.1, 7.2, 7.3, 7.4, 8.0]
+                php: [7.2, 7.3, 7.4, 8.0]
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -123,7 +123,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.1, 7.2, 7.4, 8.0]
+                php: [7.2, 7.4, 8.0]
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -151,7 +151,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.1, 7.2, 7.3, 7.4, 8.0]
+                php: [7.2, 7.3, 7.4, 8.0]
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "imagine/imagine": "^0.7.1 || ^1.0",
-        "symfony/filesystem": "^5.4",
+        "symfony/filesystem": "^5.4 || ^6.0",
         "symfony/polyfill-php73": "^1.11"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "imagine/imagine": "^0.7.1 || ^1.0",
         "symfony/filesystem": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,8 @@
         "php": "^7.1 || ^8.0",
         "ext-json": "*",
         "imagine/imagine": "^0.7.1 || ^1.0",
-        "symfony/filesystem": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/polyfill-php73": "^1.11",
-        "webmozart/path-util": "^2.0"
+        "symfony/filesystem": "^5.4",
+        "symfony/polyfill-php73": "^1.11"
     },
     "conflict": {
         "contao/imagine-svg": "<0.1.4 || >=2.0"

--- a/src/DeferredImageStorageFilesystem.php
+++ b/src/DeferredImageStorageFilesystem.php
@@ -18,7 +18,7 @@ use Contao\Image\Exception\JsonException;
 use Contao\Image\Exception\RuntimeException;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class DeferredImageStorageFilesystem implements DeferredImageStorageInterface
 {

--- a/src/DeferredImageStorageFilesystem.php
+++ b/src/DeferredImageStorageFilesystem.php
@@ -22,7 +22,7 @@ use Symfony\Component\Filesystem\Path;
 
 class DeferredImageStorageFilesystem implements DeferredImageStorageInterface
 {
-    private const PATH_PREFIX = '/deferred';
+    private const PATH_PREFIX = 'deferred';
     private const PATH_SUFFIX = '.json';
 
     /**
@@ -46,7 +46,7 @@ class DeferredImageStorageFilesystem implements DeferredImageStorageInterface
             $filesystem = new Filesystem();
         }
 
-        $this->cacheDir = $cacheDir.self::PATH_PREFIX;
+        $this->cacheDir = Path::join($cacheDir, self::PATH_PREFIX);
         $this->filesystem = $filesystem;
     }
 
@@ -196,7 +196,7 @@ class DeferredImageStorageFilesystem implements DeferredImageStorageInterface
             throw new InvalidArgumentException(sprintf('Invalid storage key "%s"', $path));
         }
 
-        return $this->cacheDir.'/'.$path.self::PATH_SUFFIX;
+        return Path::join($this->cacheDir, $path.self::PATH_SUFFIX);
     }
 
     /**

--- a/src/DeferredResizer.php
+++ b/src/DeferredResizer.php
@@ -18,7 +18,7 @@ use Imagine\Image\Box;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Point;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class DeferredResizer extends Resizer implements DeferredResizerInterface
 {

--- a/src/DeferredResizer.php
+++ b/src/DeferredResizer.php
@@ -63,7 +63,7 @@ class DeferredResizer extends Resizer implements DeferredResizerInterface
         $config = $this->storage->get($targetPath);
 
         return new DeferredImage(
-            $this->cacheDir.'/'.$targetPath,
+            Path::join($this->cacheDir, $targetPath),
             $imagine,
             new ImageDimensions(
                 new Box(
@@ -182,12 +182,12 @@ class DeferredResizer extends Resizer implements DeferredResizerInterface
         $options = new ResizeOptions();
         $options->setImagineOptions($config['options']['imagine_options']);
 
-        $path = Path::canonicalize($this->cacheDir.'/'.$config['path']);
+        $path = Path::join($this->cacheDir, $config['path']);
 
         return parent::executeResize(
             new Image($path, $imagine, $this->filesystem),
             $coordinates,
-            $this->cacheDir.'/'.$targetPath,
+            Path::join($this->cacheDir, $targetPath),
             $options
         );
     }

--- a/src/Image.php
+++ b/src/Image.php
@@ -21,7 +21,7 @@ use Imagine\Image\BoxInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Metadata\MetadataBag;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class Image implements ImageInterface
 {

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -157,7 +157,7 @@ class Resizer implements ResizerInterface
             return $this->createImage($image, $image->getPath());
         }
 
-        $cachePath = $this->cacheDir.'/'.$this->createCachePath($image->getPath(), $coordinates, $options);
+        $cachePath = Path::join($this->cacheDir, $this->createCachePath($image->getPath(), $coordinates, $options));
 
         if ($this->filesystem->exists($cachePath) && !$options->getBypassCache()) {
             return $this->createImage($image, $cachePath);
@@ -213,6 +213,6 @@ class Resizer implements ResizerInterface
         $pathinfo = pathinfo($path);
         $extension = $options->getImagineOptions()['format'] ?? strtolower($pathinfo['extension']);
 
-        return $hash[0].'/'.$pathinfo['filename'].'-'.substr($hash, 1).'.'.$extension;
+        return Path::join($hash[0], $pathinfo['filename'].'-'.substr($hash, 1).'.'.$extension);
     }
 }

--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -16,7 +16,7 @@ use Imagine\Exception\RuntimeException as ImagineRuntimeException;
 use Imagine\Filter\Basic\Autorotate;
 use Imagine\Image\Palette\RGB;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 class Resizer implements ResizerInterface
 {

--- a/tests/DeferredImageStorageFilesystemTest.php
+++ b/tests/DeferredImageStorageFilesystemTest.php
@@ -18,6 +18,7 @@ use Contao\Image\Exception\JsonException;
 use Contao\Image\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 class DeferredImageStorageFilesystemTest extends TestCase
 {
@@ -33,7 +34,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
     {
         parent::setUp();
 
-        $this->rootDir = __DIR__.'/tmp';
+        $this->rootDir = Path::canonicalize(__DIR__.'/tmp');
     }
 
     /**
@@ -79,7 +80,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
 
         $this->assertSame($value, $storage->getLocked($key));
 
-        $dataPath = $this->rootDir.'/deferred/'.$key.'.json';
+        $dataPath = Path::join($this->rootDir, 'deferred', $key.'.json');
         $handle = fopen($dataPath, 'r+');
 
         $this->assertFalse(flock($handle, LOCK_EX | LOCK_NB), 'Data file should be locked');
@@ -129,10 +130,10 @@ class DeferredImageStorageFilesystemTest extends TestCase
     {
         $storage = new DeferredImageStorageFilesystem($this->rootDir);
 
-        if (!is_dir($this->rootDir.'/deferred')) {
-            mkdir($this->rootDir.'/deferred', 0777, true);
+        if (!is_dir(Path::join($this->rootDir, 'deferred'))) {
+            mkdir(Path::join($this->rootDir, 'deferred'), 0777, true);
         }
-        file_put_contents($this->rootDir.'/deferred/test.json', 'invalid JSON');
+        file_put_contents(Path::join($this->rootDir, 'deferred/test.json'), 'invalid JSON');
 
         $this->expectException(JsonException::class);
 
@@ -143,10 +144,10 @@ class DeferredImageStorageFilesystemTest extends TestCase
     {
         $storage = new DeferredImageStorageFilesystem($this->rootDir);
 
-        if (!is_dir($this->rootDir.'/deferred')) {
-            mkdir($this->rootDir.'/deferred', 0777, true);
+        if (!is_dir(Path::join($this->rootDir, 'deferred'))) {
+            mkdir(Path::join($this->rootDir, 'deferred'), 0777, true);
         }
-        file_put_contents($this->rootDir.'/deferred/test.json', '"JSON string instead of an array"');
+        file_put_contents(Path::join($this->rootDir, 'deferred/test.json'), '"JSON string instead of an array"');
 
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/ImageTest.php
+++ b/tests/ImageTest.php
@@ -26,6 +26,7 @@ use Imagine\Image\Metadata\MetadataBag;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 
 class ImageTest extends TestCase
 {
@@ -41,7 +42,7 @@ class ImageTest extends TestCase
     {
         parent::setUp();
 
-        $this->rootDir = __DIR__.'/tmp';
+        $this->rootDir = Path::canonicalize(__DIR__.'/tmp');
     }
 
     /**
@@ -201,9 +202,9 @@ class ImageTest extends TestCase
             ->get('jpg')
         ;
 
-        file_put_contents($this->rootDir.'/dummy.jpg', $this->addImageOrientation($image, $orientation));
+        file_put_contents(Path::join($this->rootDir, 'dummy.jpg'), $this->addImageOrientation($image, $orientation));
 
-        $image = $this->createImage($this->rootDir.'/dummy.jpg');
+        $image = $this->createImage(Path::join($this->rootDir, 'dummy.jpg'));
 
         $dimensions = $image->getDimensions();
 
@@ -270,9 +271,9 @@ class ImageTest extends TestCase
         ;
 
         // Only store the first 500 bytes of the image
-        file_put_contents($this->rootDir.'/dummy.jpg', substr($image, 0, 500));
+        file_put_contents(Path::join($this->rootDir, 'dummy.jpg'), substr($image, 0, 500));
 
-        $image = $this->createImage($this->rootDir.'/dummy.jpg');
+        $image = $this->createImage(Path::join($this->rootDir, 'dummy.jpg'));
 
         $this->assertEquals(new ImageDimensions(new Box(1000, 1000)), $image->getDimensions());
     }
@@ -290,9 +291,9 @@ class ImageTest extends TestCase
         }
 
         // Only store a partial SVG file without an end tag
-        file_put_contents($this->rootDir.'/dummy.svg', '<svg width="1000" height="1000">');
+        file_put_contents(Path::join($this->rootDir, 'dummy.svg'), '<svg width="1000" height="1000">');
 
-        $image = $this->createImage($this->rootDir.'/dummy.svg', $imagine);
+        $image = $this->createImage(Path::join($this->rootDir, 'dummy.svg'), $imagine);
 
         $this->assertSame(1000, $image->getDimensions()->getSize()->getWidth());
         $this->assertSame(1000, $image->getDimensions()->getSize()->getHeight());
@@ -313,9 +314,9 @@ class ImageTest extends TestCase
         }
 
         // Only store a partial SVG file without an end tag
-        file_put_contents($this->rootDir.'/dummy.svgz', gzencode('<svg width="1000" height="1000">'));
+        file_put_contents(Path::join($this->rootDir, 'dummy.svgz'), gzencode('<svg width="1000" height="1000">'));
 
-        $image = $this->createImage($this->rootDir.'/dummy.svgz', $imagine);
+        $image = $this->createImage(Path::join($this->rootDir, 'dummy.svgz'), $imagine);
 
         $this->assertSame(1000, $image->getDimensions()->getSize()->getWidth());
         $this->assertSame(1000, $image->getDimensions()->getSize()->getHeight());
@@ -329,7 +330,7 @@ class ImageTest extends TestCase
             mkdir($this->rootDir, 0777, true);
         }
 
-        file_put_contents($this->rootDir.'/dummy.svg', '<nosvg width="1000" height="1000"></nosvg>');
+        file_put_contents(Path::join($this->rootDir, 'dummy.svg'), '<nosvg width="1000" height="1000"></nosvg>');
 
         $imagine = $this->createMock(Imagine::class);
         $imagine
@@ -337,7 +338,7 @@ class ImageTest extends TestCase
             ->willThrowException(new \Exception())
         ;
 
-        $image = $this->createImage($this->rootDir.'/dummy.svg', $imagine);
+        $image = $this->createImage(Path::join($this->rootDir, 'dummy.svg'), $imagine);
 
         $this->expectException('Exception');
         $image->getDimensions();


### PR DESCRIPTION
Closes https://github.com/contao/image/issues/86

This PR requires `symfony/filesystem` in version 5.4 and drops the abandoned `webmozart/path-util`. This effectively enforces at least PHP 7.2, so I dropped the 7.1 runs from the CI and updated our PHP requirement as well.

I also refactored the usage of string concatenation to `Path::join()` calls in  https://github.com/contao/image/commit/ebcf6622b5a469bee02f40c80371ae6a2ef74051 and https://github.com/contao/image/pull/89/commits/4ca666dd81a331809a5a3b2f39c54c0c91b6e114.
