### PR TITLE
Version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+
+## [1.2.0] (2023-05-30)
+
  * Add EXIF, IPTC, XMP metadata handling for JPEG, PNG, WEBP, GIF, HEIC, JXL, AVIF. [#93], [#95], [#96]
  * Improve file name hashing algorithm. [#90]
  * Fix wrong exception class being thrown.
@@ -135,7 +138,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  * Initial release
 
-[Unreleased]: https://github.com/contao/image/compare/1.1.2...HEAD
+[Unreleased]: https://github.com/contao/image/compare/1.2.0...1.x
+[1.2.0]: https://github.com/contao/image/compare/1.1.2...1.2.0
 [1.1.2]: https://github.com/contao/image/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/contao/image/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/contao/image/compare/1.0.3...1.1.0


### PR DESCRIPTION
Full diff since last released version: https://github.com/contao/image/compare/1.1.2...ausi:release/1.2.0

There are some bigger changes, so I wanted to recheck with @contao/developers if releasing 1.2.0 now is OK for everybody.

- The new improved file name hashing algorithm (#90) is only activated when the kernel secret is passed to the constructor, so nothing should change there for existing Contao versions.
- With the new metadata handling (#93) the copyright info is now kept in the image data by default. This will be configurable only in Contao 5.2 but that should be OK I think.
- Everything else should only be minor new features and deprecations.