### PR TITLE
Catch exceptions when JSON decoding fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+ * Handle corrupt JSON files in deferred image storage. [#110]
 
 ## [1.2.2] (2024-10-02)
 
@@ -175,6 +176,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.2.0]: https://github.com/contao/image/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/contao/image/commits/0.1.0
 
+[#110]: https://github.com/contao/image/issues/110
 [#108]: https://github.com/contao/image/issues/108
 [#104]: https://github.com/contao/image/issues/104
 [#101]: https://github.com/contao/image/issues/101

--- a/src/DeferredResizer.php
+++ b/src/DeferredResizer.php
@@ -95,11 +95,9 @@ class DeferredResizer extends Resizer implements DeferredResizerInterface
         try {
             $config = $this->storage->get($targetPath);
         } catch (\Throwable $exception) {
-            $this->storage->delete($targetPath);
-
+            // Ignore storage failure
             return null;
         }
-
 
         return new DeferredImage(
             Path::join($this->cacheDir, $targetPath),

--- a/src/DeferredResizer.php
+++ b/src/DeferredResizer.php
@@ -92,7 +92,14 @@ class DeferredResizer extends Resizer implements DeferredResizerInterface
             return null;
         }
 
-        $config = $this->storage->get($targetPath);
+        try {
+            $config = $this->storage->get($targetPath);
+        } catch (\Throwable $exception) {
+            $this->storage->delete($targetPath);
+
+            return null;
+        }
+
 
         return new DeferredImage(
             Path::join($this->cacheDir, $targetPath),

--- a/tests/DeferredImageStorageFilesystemTest.php
+++ b/tests/DeferredImageStorageFilesystemTest.php
@@ -137,7 +137,11 @@ class DeferredImageStorageFilesystemTest extends TestCase
 
         $this->expectException(JsonException::class);
 
-        $storage->get('test');
+        try {
+            $storage->get('test');
+        } finally {
+            $this->assertFileDoesNotExist(Path::join($this->rootDir, 'deferred/test.json'));
+        }
     }
 
     public function testInvalidJsonDataThrows(): void
@@ -151,7 +155,11 @@ class DeferredImageStorageFilesystemTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
 
-        $storage->get('test');
+        try {
+            $storage->get('test');
+        } finally {
+            $this->assertFileDoesNotExist(Path::join($this->rootDir, 'deferred/test.json'));
+        }
     }
 
     public function testInvalidUtf8Throws(): void

--- a/tests/DeferredImageStorageFilesystemTest.php
+++ b/tests/DeferredImageStorageFilesystemTest.php
@@ -140,7 +140,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
         try {
             $storage->get('test');
         } finally {
-            $this->assertFilenotExists(Path::join($this->rootDir, 'deferred/test.json'));
+            $this->assertFileNotExists(Path::join($this->rootDir, 'deferred/test.json'));
         }
     }
 
@@ -158,7 +158,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
         try {
             $storage->get('test');
         } finally {
-            $this->assertFilenotExists(Path::join($this->rootDir, 'deferred/test.json'));
+            $this->assertFileNotExists(Path::join($this->rootDir, 'deferred/test.json'));
         }
     }
 

--- a/tests/DeferredImageStorageFilesystemTest.php
+++ b/tests/DeferredImageStorageFilesystemTest.php
@@ -140,7 +140,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
         try {
             $storage->get('test');
         } finally {
-            $this->assertFileDoesNotExist(Path::join($this->rootDir, 'deferred/test.json'));
+            $this->assertFilenotExists(Path::join($this->rootDir, 'deferred/test.json'));
         }
     }
 
@@ -158,7 +158,7 @@ class DeferredImageStorageFilesystemTest extends TestCase
         try {
             $storage->get('test');
         } finally {
-            $this->assertFileDoesNotExist(Path::join($this->rootDir, 'deferred/test.json'));
+            $this->assertFilenotExists(Path::join($this->rootDir, 'deferred/test.json'));
         }
     }
 
@@ -229,6 +229,15 @@ class DeferredImageStorageFilesystemTest extends TestCase
             parent::assertMatchesRegularExpression($pattern, $string, $message);
         } else {
             parent::assertRegExp($pattern, $string, $message);
+        }
+    }
+
+    public static function assertFileNotExists(string $filename, string $message = ''): void
+    {
+        if (method_exists(parent::class, 'assertFileDoesNotExist')) {
+            parent::assertFileDoesNotExist($filename, $message);
+        } else {
+            parent::assertFileNotExists($filename, $message);
         }
     }
 }

--- a/tests/DeferredResizerTest.php
+++ b/tests/DeferredResizerTest.php
@@ -17,6 +17,7 @@ use Contao\Image\DeferredImageStorageInterface;
 use Contao\Image\DeferredResizer;
 use Contao\Image\Exception\FileNotExistsException;
 use Contao\Image\Exception\InvalidArgumentException;
+use Contao\Image\Exception\JsonException;
 use Contao\Image\Exception\RuntimeException;
 use Contao\Image\Image;
 use Contao\Image\ImageDimensions;
@@ -223,6 +224,28 @@ class DeferredResizerTest extends TestCase
         $imagePath = Path::join($this->rootDir, 'a/foo-5fc1c9f9.jpg');
 
         $this->assertNull($resizer->getDeferredImage($imagePath, $imagine));
+    }
+
+    public function testGetCorruptDeferredImage(): void
+    {
+        $storage = $this->createMock(DeferredImageStorageInterface::class);
+        $storage
+            ->method('has')
+            ->willReturn(true)
+        ;
+
+        $storage
+            ->method('get')
+            ->with('a/foo-5fc1c9f9.jpg')
+            ->willThrowException(new JsonException('JSON error'))
+        ;
+
+        $imagine = $this->createMock(ImagineInterface::class);
+        $resizer = $this->createResizer(null, null, null, $storage);
+        $imagePath = Path::join($this->rootDir, 'a/foo-5fc1c9f9.jpg');
+        $deferredImage = $resizer->getDeferredImage($imagePath, $imagine);
+
+        $this->assertNull($deferredImage);
     }
 
     public function testResizeDeferredImageThrowsForOutsidePath(): void


### PR DESCRIPTION
If somehow there's an error writing the config to the storage, you'll end up getting `Uncaught PHP Exception Contao\Image\Exception\JsonException: "Syntax error" at DeferredImageStorageFilesystem.php line 210` because the `has()` check does not validate the syntax.