### PR TITLE
Handle null-values of XML attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+ * Handle missing attribute namespace in XMP. [#112]
 
 ## [1.2.3] (2025-02-13)
 
@@ -180,6 +181,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 [0.2.0]: https://github.com/contao/image/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/contao/image/commits/0.1.0
 
+[#112]: https://github.com/contao/image/issues/112
 [#110]: https://github.com/contao/image/issues/110
 [#108]: https://github.com/contao/image/issues/108
 [#104]: https://github.com/contao/image/issues/104

--- a/src/Metadata/XmpFormat.php
+++ b/src/Metadata/XmpFormat.php
@@ -175,28 +175,28 @@ class XmpFormat extends AbstractFormat
         $foundDescription = false;
         $metadata = [];
 
-        foreach ($this->loadXml($binaryChunk)->getElementsByTagNameNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'RDF') as $rdf) {
-            foreach ($rdf->childNodes ?? [] as $desc) {
-                if ('Description' !== $desc->localName || 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' !== $desc->namespaceURI) {
-                    continue;
-                }
-
-                $foundDescription = true;
-
-                foreach ($desc->attributes ?? [] as $attr) {
-                    if ($attr->namespaceURI && $attr->localName) {
-                        $metadata[] = $this->parseValue($attr->namespaceURI, $attr->localName, $attr->value);
+        try {
+            foreach ($this->loadXml($binaryChunk)->getElementsByTagNameNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'RDF') as $rdf) {
+                foreach ($rdf->childNodes ?? [] as $desc) {
+                    if ('Description' !== $desc->localName || 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' !== $desc->namespaceURI) {
+                        continue;
                     }
-                }
 
-                foreach ($desc->childNodes ?? [] as $node) {
-                    if ($node instanceof \DOMElement) {
-                        if ($node->namespaceURI && $node->localName) {
+                    $foundDescription = true;
+
+                    foreach ($desc->attributes ?? [] as $attr) {
+                        $metadata[] = $this->parseValue($attr->namespaceURI ?? $desc->namespaceURI, $attr->localName, $attr->value);
+                    }
+
+                    foreach ($desc->childNodes ?? [] as $node) {
+                        if ($node instanceof \DOMElement) {
                             $metadata[] = $this->parseValue($node->namespaceURI, $node->localName, $node);
                         }
                     }
                 }
             }
+        } catch (\Throwable $exception) {
+            throw new InvalidImageMetadataException('Parsing XMP metadata failed', 0, $exception);
         }
 
         if (!$foundDescription) {
@@ -312,14 +312,23 @@ class XmpFormat extends AbstractFormat
             $disableEntities = libxml_disable_entity_loader();
         }
 
-        $document = new \DOMDocument();
-        $document->loadXML($xml, LIBXML_NONET);
+        try {
+            $document = new \DOMDocument();
 
-        libxml_clear_errors();
-        libxml_use_internal_errors($internalErrors);
+            if (!$document->loadXML($xml, LIBXML_NONET)) {
+                if ($error = libxml_get_last_error()) {
+                    throw new \ErrorException($error->message, $error->code, E_ERROR, null, $error->line);
+                }
 
-        if (LIBXML_VERSION < 20900) {
-            libxml_disable_entity_loader($disableEntities);
+                throw new \ErrorException('XML parse error');
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($internalErrors);
+
+            if (LIBXML_VERSION < 20900) {
+                libxml_disable_entity_loader($disableEntities);
+            }
         }
 
         return $document;

--- a/src/Metadata/XmpFormat.php
+++ b/src/Metadata/XmpFormat.php
@@ -184,12 +184,16 @@ class XmpFormat extends AbstractFormat
                 $foundDescription = true;
 
                 foreach ($desc->attributes ?? [] as $attr) {
-                    $metadata[] = $this->parseValue($attr->namespaceURI, $attr->localName, $attr->value);
+                    if ($attr->namespaceURI && $attr->localName) {
+                        $metadata[] = $this->parseValue($attr->namespaceURI, $attr->localName, $attr->value);
+                    }
                 }
 
                 foreach ($desc->childNodes ?? [] as $node) {
                     if ($node instanceof \DOMElement) {
-                        $metadata[] = $this->parseValue($node->namespaceURI, $node->localName, $node);
+                        if ($node->namespaceURI && $node->localName) {
+                            $metadata[] = $this->parseValue($node->namespaceURI, $node->localName, $node);
+                        }
                     }
                 }
             }

--- a/tests/Metadata/XmpFormatTest.php
+++ b/tests/Metadata/XmpFormatTest.php
@@ -101,9 +101,39 @@ class XmpFormatTest extends TestCase
         ];
 
         yield [
+            '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:iX="http://ns.adobe.com/iX/1.0/">'
+            .'<rdf:Description>'
+            .'<creator>missing namespace</creator>'
+            .'</rdf:Description>'
+            .'</rdf:RDF>',
+            [],
+            [],
+        ];
+
+        yield [
             'NOT XMP',
             [],
             [],
+        ];
+
+        yield [
+            '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:iX="http://ns.adobe.com/iX/1.0/">'
+            .'<rdf:Description about="missing-namespace-prefix" xmlns:xapMM="http://ns.adobe.com/xap/1.0/mm/">'
+            .'<xapMM:DocumentID>adobe:docid:photoshop:00000000-0000-1000-8000-000000000000</xapMM:DocumentID>'
+            .'</rdf:Description>'
+            .'</rdf:RDF>',
+            [
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#' => [
+                    'about' => ['missing-namespace-prefix'],
+                ],
+                'http://ns.adobe.com/xap/1.0/mm/' => [
+                    'DocumentID' => ['adobe:docid:photoshop:00000000-0000-1000-8000-000000000000'],
+                ],
+            ],
+            [
+                'rdf:about' => ['missing-namespace-prefix'],
+                'xmpMM:DocumentID' => ['adobe:docid:photoshop:00000000-0000-1000-8000-000000000000'],
+            ],
         ];
     }
 


### PR DESCRIPTION
I tried parsing an image that resulted in an exception message `Contao\Image\Metadata\XmpFormat::parseValue(): Argument #1 ($namespace) must be of type string, null given`, because the value for `$attr->namespaceURI` was null. Not sure how that can happen, and no idea how to write a test for that, but I think the library should rather ignore these values than throw an exception?