### PR TITLE
Update Resizer.php

### DIFF
--- a/src/Resizer.php
+++ b/src/Resizer.php
@@ -247,6 +247,10 @@ class Resizer implements ResizerInterface
             return $this->createImage($image, $image->getPath());
         }
 
+        if ($this->isAnimatedGif($image->getPath())) {
+            return $this->createImage($image, $image->getPath());
+        }
+
         $cachePath = Path::join($this->cacheDir, $this->createCachePath($image->getPath(), $coordinates, $options, false));
 
         if (!$options->getBypassCache()) {
@@ -364,5 +368,31 @@ class Resizer implements ResizerInterface
         }
 
         return implode('', $result);
+    }
+
+    /**
+     * Check if a file is an animated GIF.
+     */
+    private function isAnimatedGif(string $path): bool
+    {
+        if (strtolower(pathinfo($path, PATHINFO_EXTENSION)) !== 'gif') {
+            return false;
+        }
+
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        $content = file_get_contents($path, false, null, 0, 3145728);
+
+        if ($content === false) {
+            return false;
+        }
+
+        // Count occurrences of the GIF image separator byte
+        // Animated GIFs have multiple image blocks (0x00,0x21,0xF9)
+        $count = preg_match_all('#\x00\x21\xF9\x04#', $content, $matches);
+
+        return $count > 1;
     }
 }


### PR DESCRIPTION
Prevent animated GIF endless loop (Error 502)

Our customer has multiple animated GIF in Backend. Those cause slowed down backend and 502 Errors. What i see in the logs:

1. Imagine Library Limitation: The Imagine library cannot properly process animated GIFs
2. Frame Loss: During resize/crop operations, all frames except the first are discarded
3. Invalid Cache: The cached result was a corrupted/incomplete GIF
4. Recursion on Load: Attempting to load these invalid cached images triggered repeated processing attempts

Causing:

1. 502 Bad Gateway errors when opening GIF files in Contao backend
2. PHP memory limit or execution timeout due to deep recursion
3. Custom server logs show repetitive processResize calls for the same file (Parent function was never called)

So i've made a little check to skip animated gifs.